### PR TITLE
feat: adicionar sidebar responsiva para operador

### DIFF
--- a/public/js/pages/operador-agenda.js
+++ b/public/js/pages/operador-agenda.js
@@ -11,13 +11,6 @@ export function initOperadorAgenda(userId, userRole) {
 }
 
 function bindUI() {
-  const openBtn = document.getElementById('openSidebarBtn');
-  const mobileSidebar = document.getElementById('mobileSidebar');
-  const closeBtn = document.getElementById('closeSidebarBtn');
-  const closeMenu = document.getElementById('closeMobileMenu');
-  openBtn?.addEventListener('click', () => mobileSidebar?.classList.remove('hidden'));
-  closeBtn?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
-  closeMenu?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
   document.getElementById('prevMonth')?.addEventListener('click', () => {
     state.currentMonth.setMonth(state.currentMonth.getMonth() - 1);
     loadAgenda();

--- a/public/js/pages/operador-ordens.js
+++ b/public/js/pages/operador-ordens.js
@@ -37,11 +37,4 @@ function renderTable(ordens) {
 }
 
 function bindUI() {
-  const openBtn = document.getElementById('openSidebarBtn');
-  const mobileSidebar = document.getElementById('mobileSidebar');
-  const closeBtn = document.getElementById('closeSidebarBtn');
-  const closeMenu = document.getElementById('closeMobileMenu');
-  openBtn?.addEventListener('click', () => mobileSidebar?.classList.remove('hidden'));
-  closeBtn?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
-  closeMenu?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
 }

--- a/public/js/pages/operador-perfil.js
+++ b/public/js/pages/operador-perfil.js
@@ -14,11 +14,4 @@ function renderProfile() {
 }
 
 function bindUI() {
-  const openBtn = document.getElementById('openSidebarBtn');
-  const mobileSidebar = document.getElementById('mobileSidebar');
-  const closeBtn = document.getElementById('closeSidebarBtn');
-  const closeMenu = document.getElementById('closeMobileMenu');
-  openBtn?.addEventListener('click', () => mobileSidebar?.classList.remove('hidden'));
-  closeBtn?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
-  closeMenu?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
 }

--- a/public/js/pages/operador-tarefas.js
+++ b/public/js/pages/operador-tarefas.js
@@ -57,14 +57,6 @@ const tbody = document.getElementById('tasksList');
 }
 
 function bindUI() {
-  const openBtn = document.getElementById('openSidebarBtn');
-  const mobileSidebar = document.getElementById('mobileSidebar');
-  const closeBtn = document.getElementById('closeSidebarBtn');
-  const closeMenu = document.getElementById('closeMobileMenu');
-  openBtn?.addEventListener('click', () => mobileSidebar?.classList.remove('hidden'));
-  closeBtn?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
-  closeMenu?.addEventListener('click', () => mobileSidebar?.classList.add('hidden'));
-
   const modal = document.getElementById('taskModal');
   const closeModal = document.getElementById('closeTaskModal');
   closeModal?.addEventListener('click', hideTaskModal);

--- a/public/js/ui/sidebar.js
+++ b/public/js/ui/sidebar.js
@@ -1,0 +1,110 @@
+// public/js/ui/sidebar.js
+// Sidebar: toggle, active state and Firestore counters
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const sidebar = document.getElementById('sidebar');
+  const toggle = document.getElementById('sidebarToggle');
+  const backdrop = document.getElementById('sidebarBackdrop');
+
+  const open = () => {
+    sidebar?.classList.add('open');
+    backdrop?.classList.add('show');
+    toggle?.setAttribute('aria-expanded', 'true');
+  };
+
+  const close = () => {
+    sidebar?.classList.remove('open');
+    backdrop?.classList.remove('show');
+    toggle?.setAttribute('aria-expanded', 'false');
+  };
+
+  toggle?.addEventListener('click', () => {
+    sidebar?.classList.contains('open') ? close() : open();
+  });
+
+  backdrop?.addEventListener('click', close);
+
+  // Active link
+  const current = window.location.pathname.split('/').pop();
+  document.querySelectorAll('#sidebar a').forEach(link => {
+    if (link.getAttribute('href') === current) {
+      link.classList.add('is-active');
+      link.setAttribute('aria-current', 'page');
+    }
+  });
+
+  try {
+    const { db } = await import('../config/firebase.js');
+    const {
+      collection,
+      query,
+      where,
+      onSnapshot,
+      Timestamp
+    } = await import('https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js');
+
+    // Badges: tarefas pending+running
+    const tasksBadge = document.getElementById('tasksBadge');
+    if (tasksBadge) {
+      const q = query(collection(db, 'tarefas'), where('status', 'in', ['pending', 'running']));
+      onSnapshot(q, snap => {
+        const count = snap.size;
+        tasksBadge.textContent = count;
+        tasksBadge.classList.toggle('show', count > 0);
+      });
+    }
+
+    // Badges: ordens abertas
+    const ordersBadge = document.getElementById('ordersBadge');
+    if (ordersBadge) {
+      const q = query(collection(db, 'ordens'), where('status', '==', 'aberta'));
+      onSnapshot(q, snap => {
+        const count = snap.size;
+        ordersBadge.textContent = count;
+        ordersBadge.classList.toggle('show', count > 0);
+      });
+    }
+
+    // Agenda indicator
+    const agendaIndicator = document.getElementById('agendaIndicator');
+    if (agendaIndicator) {
+      const tz = 'America/Sao_Paulo';
+      const now = new Date();
+      const today = new Date(now.toLocaleString('en-US', { timeZone: tz }));
+      today.setHours(0, 0, 0, 0);
+      const start = Timestamp.fromDate(today);
+      const end = Timestamp.fromDate(new Date(today.getTime() + 86400000 - 1));
+      const todayStr = today.toISOString().slice(0, 10);
+
+      let tasksToday = false;
+      let ordersToday = false;
+
+      const updateIndicator = () => {
+        agendaIndicator.classList.toggle('show', tasksToday || ordersToday);
+      };
+
+      const tarefasCol = collection(db, 'tarefas');
+      onSnapshot(query(tarefasCol, where('vencimento', '>=', start), where('vencimento', '<=', end)), snap => {
+        tasksToday = snap.size > 0;
+        updateIndicator();
+      });
+      onSnapshot(query(tarefasCol, where('vencimento', '==', todayStr)), snap => {
+        tasksToday = tasksToday || snap.size > 0;
+        updateIndicator();
+      });
+
+      const ordensCol = collection(db, 'ordens');
+      onSnapshot(query(ordensCol, where('prazo', '>=', start), where('prazo', '<=', end)), snap => {
+        ordersToday = snap.size > 0;
+        updateIndicator();
+      });
+      onSnapshot(query(ordensCol, where('prazo', '==', todayStr)), snap => {
+        ordersToday = ordersToday || snap.size > 0;
+        updateIndicator();
+      });
+    }
+  } catch (err) {
+    console.error('Firestore unavailable', err);
+  }
+});
+

--- a/public/operador-agenda.html
+++ b/public/operador-agenda.html
@@ -9,59 +9,47 @@
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="h-screen flex bg-gray-100">
+<body class="min-h-screen bg-gray-100">
   <div id="operador-agenda-marker" class="hidden"></div>
-  <!-- Sidebar desktop -->
-  <nav id="sidebar" class="hidden md:block w-64 bg-white border-r">
-    <div class="p-4 text-xl font-bold text-green-700">Orgânia</div>
-    <ul class="px-4 space-y-2">
-      <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-      <li><a href="operador-ordens.html" class="block py-2 px-2 rounded hover:bg-green-100">Ordens</a></li>
-      <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded hover:bg-green-100">Tarefas</a></li>
-      <li><a href="operador-agenda.html" class="block py-2 px-2 rounded bg-green-100">Agenda</a></li>
-      <li><a href="operador-perfil.html" class="block py-2 px-2 rounded hover:bg-green-100">Perfil</a></li>
-    </ul>
-  </nav>
 
-  <!-- Sidebar mobile -->
-  <div id="mobileSidebar" class="fixed inset-0 z-40 hidden md:hidden">
-    <div id="closeMobileMenu" class="absolute inset-0 bg-black bg-opacity-50"></div>
-    <nav class="relative w-64 h-full bg-white p-4">
-      <button id="closeSidebarBtn" class="mb-4"><i class="fas fa-times"></i></button>
-      <ul class="space-y-2">
-        <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-        <li><a href="operador-ordens.html" class="block py-2 px-2 rounded hover:bg-green-100">Ordens</a></li>
-        <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded hover:bg-green-100">Tarefas</a></li>
-        <li><a href="operador-agenda.html" class="block py-2 px-2 rounded bg-green-100">Agenda</a></li>
-        <li><a href="operador-perfil.html" class="block py-2 px-2 rounded hover:bg-green-100">Perfil</a></li>
-      </ul>
+  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+    <i class="fas fa-bars"></i>
+  </button>
+  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+
+  <aside id="sidebar" class="sidebar">
+    <div class="sidebar-logo">
+      <img src="logo.png" alt="Orgânia" />
+    </div>
+    <!-- Links podem receber data-role para controle de acesso -->
+    <nav class="sidebar-nav">
+      <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-clipboard-list"></i><span>Ordens</span><span id="ordersBadge" class="sidebar-badge"></span></a>
+      <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
+      <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
-  </div>
+  </aside>
 
-  <div class="flex-1 flex flex-col overflow-hidden">
+  <main class="main-content flex flex-col overflow-hidden">
     <header class="bg-white border-b">
       <div class="flex items-center justify-between px-4 py-2">
-        <div class="flex items-center">
-          <button id="openSidebarBtn" class="md:hidden mr-2" aria-label="Abrir menu">
-            <i class="fas fa-bars"></i>
-          </button>
-          <h1 class="text-lg font-bold text-green-700">Agenda</h1>
-        </div>
+        <h1 class="text-lg font-bold text-green-700">Agenda</h1>
         <button onclick="logout()" class="text-red-600 font-semibold">Sair</button>
       </div>
     </header>
 
-    <main class="flex-1 overflow-y-auto p-4">
-      <section class="bg-white rounded-lg shadow-lg p-4">
+    <section class="flex-1 overflow-y-auto p-4">
+      <div class="bg-white rounded-lg shadow-lg p-4">
         <div class="flex justify-between items-center mb-2">
           <button id="prevMonth" class="p-1 rounded hover:bg-gray-200" aria-label="Mês anterior">&lt;</button>
           <h2 id="monthLabel" class="text-lg font-bold"></h2>
           <button id="nextMonth" class="p-1 rounded hover:bg-gray-200" aria-label="Próximo mês">&gt;</button>
         </div>
         <table id="calendarTable" class="w-full text-center text-sm"></table>
-      </section>
-    </main>
-  </div>
+      </div>
+    </section>
+  </main>
 
   <!-- Modal Agenda Diária -->
   <div id="dailyAgendaModal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-50 p-4" role="dialog" aria-modal="true">
@@ -74,6 +62,7 @@
     </div>
   </div>
 
+  <script type="module" src="js/ui/sidebar.js"></script>
   <script type="module" src="js/services/auth.js"></script>
 </body>
 </html>

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -16,21 +16,40 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="min-h-screen bg-gray-100 text-gray-800">
-
   <div id="operador-dashboard-marker" class="hidden"></div>
 
-  <header class="dashboard-header shadow-md">
-    <div class="dashboard-container flex justify-between items-center h-16">
-      <div class="flex items-center space-x-4">
-        <img src="logo.png" alt="Orgânia" class="dashboard-logo" />
-        <h1 class="text-2xl font-semibold">Dashboard do Operador</h1>
-      </div>
-      <button id="logoutBtn" class="dashboard-btn flex items-center text-sm"><i class="fas fa-sign-out-alt mr-2"></i>Sair</button>
-    </div>
-  </header>
+  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+    <i class="fas fa-bars"></i>
+  </button>
+  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
 
-  <!-- CONTEÚDO PRINCIPAL -->
-  <div class="dashboard-container flex flex-col py-6">
+  <aside id="sidebar" class="sidebar">
+    <div class="sidebar-logo">
+      <img src="logo.png" alt="Orgânia" />
+    </div>
+    <!-- Links podem receber data-role para controle de acesso -->
+    <nav class="sidebar-nav">
+      <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-clipboard-list"></i><span>Ordens</span><span id="ordersBadge" class="sidebar-badge"></span></a>
+      <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
+      <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
+    </nav>
+  </aside>
+
+  <main class="main-content">
+    <header class="dashboard-header shadow-md">
+      <div class="dashboard-container flex justify-between items-center h-16">
+        <div class="flex items-center space-x-4">
+          <img src="logo.png" alt="Orgânia" class="dashboard-logo" />
+          <h1 class="text-2xl font-semibold">Dashboard do Operador</h1>
+        </div>
+        <button id="logoutBtn" class="dashboard-btn flex items-center text-sm"><i class="fas fa-sign-out-alt mr-2"></i>Sair</button>
+      </div>
+    </header>
+
+    <!-- CONTEÚDO PRINCIPAL -->
+    <div class="dashboard-container flex flex-col py-6">
 
     <!-- MÉTRICAS -->
 <section class="dashboard-section grid grid-cols-1 sm:grid-cols-4 gap-4 mb-6">
@@ -101,7 +120,8 @@
         </div>
       </section>
     </section>
-  </div>
+    </div>
+  </main>
 
   <div id="taskModal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden">
     <div class="bg-white rounded-lg shadow-lg p-6 w-80">
@@ -126,5 +146,7 @@
       </form>
     </div>
   </div>
+
+  <script type="module" src="js/ui/sidebar.js"></script>
 </body>
 </html>

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -9,50 +9,38 @@
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="h-screen flex bg-gray-100">
+<body class="min-h-screen bg-gray-100">
   <div id="operador-ordens-marker" class="hidden"></div>
-  <!-- Sidebar desktop -->
-  <nav id="sidebar" class="hidden md:block w-64 bg-white border-r">
-    <div class="p-4 text-xl font-bold text-green-700">Orgânia</div>
-    <ul class="px-4 space-y-2">
-      <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-      <li><a href="operador-ordens.html" class="block py-2 px-2 rounded bg-green-100">Ordens</a></li>
-      <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded hover:bg-green-100">Tarefas</a></li>
-      <li><a href="operador-agenda.html" class="block py-2 px-2 rounded hover:bg-green-100">Agenda</a></li>
-      <li><a href="operador-perfil.html" class="block py-2 px-2 rounded hover:bg-green-100">Perfil</a></li>
-    </ul>
-  </nav>
 
-  <!-- Sidebar mobile -->
-  <div id="mobileSidebar" class="fixed inset-0 z-40 hidden md:hidden">
-    <div id="closeMobileMenu" class="absolute inset-0 bg-black bg-opacity-50"></div>
-    <nav class="relative w-64 h-full bg-white p-4">
-      <button id="closeSidebarBtn" class="mb-4"><i class="fas fa-times"></i></button>
-      <ul class="space-y-2">
-        <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-        <li><a href="operador-ordens.html" class="block py-2 px-2 rounded bg-green-100">Ordens</a></li>
-        <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded hover:bg-green-100">Tarefas</a></li>
-        <li><a href="operador-agenda.html" class="block py-2 px-2 rounded hover:bg-green-100">Agenda</a></li>
-        <li><a href="operador-perfil.html" class="block py-2 px-2 rounded hover:bg-green-100">Perfil</a></li>
-      </ul>
+  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+    <i class="fas fa-bars"></i>
+  </button>
+  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+
+  <aside id="sidebar" class="sidebar">
+    <div class="sidebar-logo">
+      <img src="logo.png" alt="Orgânia" />
+    </div>
+    <!-- Links podem receber data-role para controle de acesso -->
+    <nav class="sidebar-nav">
+      <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-clipboard-list"></i><span>Ordens</span><span id="ordersBadge" class="sidebar-badge"></span></a>
+      <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
+      <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
-  </div>
+  </aside>
 
-  <div class="flex-1 flex flex-col overflow-hidden">
+  <main class="main-content flex flex-col overflow-hidden">
     <header class="bg-white border-b">
       <div class="flex items-center justify-between px-4 py-2">
-        <div class="flex items-center">
-          <button id="openSidebarBtn" class="md:hidden mr-2" aria-label="Abrir menu">
-            <i class="fas fa-bars"></i>
-          </button>
-          <h1 class="text-lg font-bold text-green-700">Ordens</h1>
-        </div>
+        <h1 class="text-lg font-bold text-green-700">Ordens</h1>
         <button onclick="logout()" class="text-red-600 font-semibold">Sair</button>
       </div>
     </header>
 
-    <main class="flex-1 overflow-y-auto p-4">
-      <section class="bg-white rounded-lg shadow-lg p-4">
+    <section class="flex-1 overflow-y-auto p-4">
+      <div class="bg-white rounded-lg shadow-lg p-4">
         <h2 class="text-lg font-bold mb-4">Lista de Ordens</h2>
         <div class="overflow-x-auto">
           <table class="min-w-full text-sm text-left" id="ordersTable">
@@ -67,10 +55,11 @@
             <tbody></tbody>
           </table>
         </div>
-      </section>
-    </main>
-  </div>
+      </div>
+    </section>
+  </main>
 
+  <script type="module" src="js/ui/sidebar.js"></script>
   <script type="module" src="js/services/auth.js"></script>
 </body>
 </html>

--- a/public/operador-perfil.html
+++ b/public/operador-perfil.html
@@ -9,58 +9,47 @@
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="h-screen flex bg-gray-100">
+<body class="min-h-screen bg-gray-100">
   <div id="operador-perfil-marker" class="hidden"></div>
-  <!-- Sidebar desktop -->
-  <nav id="sidebar" class="hidden md:block w-64 bg-white border-r">
-    <div class="p-4 text-xl font-bold text-green-700">Orgânia</div>
-    <ul class="px-4 space-y-2">
-      <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-      <li><a href="operador-ordens.html" class="block py-2 px-2 rounded hover:bg-green-100">Ordens</a></li>
-      <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded hover:bg-green-100">Tarefas</a></li>
-      <li><a href="operador-agenda.html" class="block py-2 px-2 rounded hover:bg-green-100">Agenda</a></li>
-      <li><a href="operador-perfil.html" class="block py-2 px-2 rounded bg-green-100">Perfil</a></li>
-    </ul>
-  </nav>
 
-  <!-- Sidebar mobile -->
-  <div id="mobileSidebar" class="fixed inset-0 z-40 hidden md:hidden">
-    <div id="closeMobileMenu" class="absolute inset-0 bg-black bg-opacity-50"></div>
-    <nav class="relative w-64 h-full bg-white p-4">
-      <button id="closeSidebarBtn" class="mb-4"><i class="fas fa-times"></i></button>
-      <ul class="space-y-2">
-        <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-        <li><a href="operador-ordens.html" class="block py-2 px-2 rounded hover:bg-green-100">Ordens</a></li>
-        <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded hover:bg-green-100">Tarefas</a></li>
-        <li><a href="operador-agenda.html" class="block py-2 px-2 rounded hover:bg-green-100">Agenda</a></li>
-        <li><a href="operador-perfil.html" class="block py-2 px-2 rounded bg-green-100">Perfil</a></li>
-      </ul>
+  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+    <i class="fas fa-bars"></i>
+  </button>
+  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+
+  <aside id="sidebar" class="sidebar">
+    <div class="sidebar-logo">
+      <img src="logo.png" alt="Orgânia" />
+    </div>
+    <!-- Links podem receber data-role para controle de acesso -->
+    <nav class="sidebar-nav">
+      <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-clipboard-list"></i><span>Ordens</span><span id="ordersBadge" class="sidebar-badge"></span></a>
+      <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
+      <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
-  </div>
+  </aside>
 
-  <div class="flex-1 flex flex-col overflow-hidden">
+  <main class="main-content flex flex-col overflow-hidden">
     <header class="bg-white border-b">
       <div class="flex items-center justify-between px-4 py-2">
-        <div class="flex items-center">
-          <button id="openSidebarBtn" class="md:hidden mr-2" aria-label="Abrir menu">
-            <i class="fas fa-bars"></i>
-          </button>
-          <h1 class="text-lg font-bold text-green-700">Perfil</h1>
-        </div>
+        <h1 class="text-lg font-bold text-green-700">Perfil</h1>
         <button onclick="logout()" class="text-red-600 font-semibold">Sair</button>
       </div>
     </header>
 
-    <main class="flex-1 overflow-y-auto p-4">
-      <section class="bg-white rounded-lg shadow-lg p-4 max-w-md">
+    <section class="flex-1 overflow-y-auto p-4">
+      <div class="bg-white rounded-lg shadow-lg p-4 max-w-md">
         <h2 class="text-lg font-bold mb-4">Informações do Usuário</h2>
         <p><span class="font-semibold">Nome:</span> <span id="profileName"></span></p>
         <p><span class="font-semibold">Email:</span> <span id="profileEmail"></span></p>
         <p><span class="font-semibold">Papel:</span> <span id="profileRole"></span></p>
-      </section>
-    </main>
-  </div>
+      </div>
+    </section>
+  </main>
 
+  <script type="module" src="js/ui/sidebar.js"></script>
   <script type="module" src="js/services/auth.js"></script>
 </body>
 </html>

--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -9,52 +9,40 @@
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="h-screen flex bg-gray-100">
+<body class="min-h-screen bg-gray-100">
   <div id="operador-tarefas-marker" class="hidden"></div>
-  <!-- Sidebar desktop -->
-  <nav id="sidebar" class="hidden md:block w-64 bg-white border-r">
-    <div class="p-4 text-xl font-bold text-green-700">Orgânia</div>
-    <ul class="px-4 space-y-2">
-      <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-      <li><a href="operador-ordens.html" class="block py-2 px-2 rounded hover:bg-green-100">Ordens</a></li>
-      <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded bg-green-100">Tarefas</a></li>
-      <li><a href="operador-agenda.html" class="block py-2 px-2 rounded hover:bg-green-100">Agenda</a></li>
-      <li><a href="operador-perfil.html" class="block py-2 px-2 rounded hover:bg-green-100">Perfil</a></li>
-    </ul>
-  </nav>
 
-  <!-- Sidebar mobile -->
-  <div id="mobileSidebar" class="fixed inset-0 z-40 hidden md:hidden">
-    <div id="closeMobileMenu" class="absolute inset-0 bg-black bg-opacity-50"></div>
-    <nav class="relative w-64 h-full bg-white p-4">
-      <button id="closeSidebarBtn" class="mb-4"><i class="fas fa-times"></i></button>
-      <ul class="space-y-2">
-        <li><a href="operador-dashboard.html" class="block py-2 px-2 rounded hover:bg-green-100">Dashboard</a></li>
-        <li><a href="operador-ordens.html" class="block py-2 px-2 rounded hover:bg-green-100">Ordens</a></li>
-        <li><a href="operador-tarefas.html" class="block py-2 px-2 rounded bg-green-100">Tarefas</a></li>
-        <li><a href="operador-agenda.html" class="block py-2 px-2 rounded hover:bg-green-100">Agenda</a></li>
-        <li><a href="operador-perfil.html" class="block py-2 px-2 rounded hover:bg-green-100">Perfil</a></li>
-      </ul>
+  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+    <i class="fas fa-bars"></i>
+  </button>
+  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+
+  <aside id="sidebar" class="sidebar">
+    <div class="sidebar-logo">
+      <img src="logo.png" alt="Orgânia" />
+    </div>
+    <!-- Links podem receber data-role para controle de acesso -->
+    <nav class="sidebar-nav">
+      <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-clipboard-list"></i><span>Ordens</span><span id="ordersBadge" class="sidebar-badge"></span></a>
+      <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
+      <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
-  </div>
+  </aside>
 
-  <div class="flex-1 flex flex-col overflow-hidden">
+  <main class="main-content flex flex-col overflow-hidden">
     <header class="bg-white border-b">
       <div class="flex items-center justify-between px-4 py-2">
-        <div class="flex items-center">
-          <button id="openSidebarBtn" class="md:hidden mr-2" aria-label="Abrir menu">
-            <i class="fas fa-bars"></i>
-          </button>
-          <h1 class="text-lg font-bold text-green-700">Tarefas</h1>
-        </div>
+        <h1 class="text-lg font-bold text-green-700">Tarefas</h1>
         <button onclick="logout()" class="text-red-600 font-semibold">Sair</button>
       </div>
     </header>
 
-    <main class="flex-1 overflow-y-auto p-4">
-      <section class="bg-white rounded-lg shadow-lg p-4">
+    <section class="flex-1 overflow-y-auto p-4">
+      <div class="bg-white rounded-lg shadow-lg p-4">
         <h2 class="text-lg font-bold mb-4">Minhas Tarefas</h2>
- <div class="overflow-x-auto">
+        <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>
@@ -67,9 +55,9 @@
             <tbody id="tasksList" class="divide-y"></tbody>
           </table>
         </div>
-      </section>
-    </main>
-  </div>
+      </div>
+    </section>
+  </main>
 
   <!-- Modal Detalhes da Tarefa -->
   <div id="taskModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
@@ -82,6 +70,7 @@
     </div>
   </div>
 
+  <script type="module" src="js/ui/sidebar.js"></script>
   <script type="module" src="js/pages/operador-tarefas.js"></script>
   <script type="module" src="js/services/auth.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -397,3 +397,151 @@ button:active, .btn:active {
         transition: none !important;
     }
 }
+
+/* Sidebar: layout and utility classes */
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 260px;
+    background: #FFFFFF;
+    border-right: 1px solid #E5E7EB;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 50;
+}
+
+.sidebar.open {
+    transform: translateX(0);
+}
+
+.sidebar-logo {
+    padding: 16px;
+}
+
+/* garante que o logo da sidebar não extrapole o layout */
+.sidebar-logo img {
+    height: 40px;
+    width: auto;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 0 8px;
+}
+
+.sidebar-link {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    color: #1F2937;
+    text-decoration: none;
+}
+
+.sidebar-link:hover {
+    background: #F3F4F6;
+}
+
+.sidebar-link.is-active {
+    background: rgba(108,159,61,0.12);
+    color: #5A8733;
+    position: relative;
+}
+
+.sidebar-link.is-active i {
+    color: #6C9F3D;
+}
+
+.sidebar-link.is-active::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: #6C9F3D;
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+}
+
+.sidebar-link:focus,
+.sidebar-toggle:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(108,159,61,0.30);
+}
+
+.sidebar-badge {
+    margin-left: auto;
+    background: #DBEAFE;
+    color: #1E40AF;
+    border-radius: 9999px;
+    padding: 0 8px;
+    font-size: 12px;
+    font-weight: 500;
+    display: none;
+}
+
+.sidebar-badge.show {
+    display: inline-block;
+}
+
+.sidebar-indicator {
+    margin-left: auto;
+    width: 8px;
+    height: 8px;
+    background: #16A34A;
+    border-radius: 50%;
+    display: none;
+}
+
+.sidebar-indicator.show {
+    display: block;
+}
+
+.sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    z-index: 40;
+    display: none;
+}
+
+.sidebar-backdrop.show {
+    display: block;
+}
+
+.sidebar-toggle {
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    z-index: 60;
+    background: #FFFFFF;
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 8px;
+    color: #1F2937;
+}
+
+.main-content {
+    padding: 0;
+}
+
+@media (min-width: 1024px) {
+    .sidebar {
+        transform: none;
+    }
+    .sidebar-toggle {
+        display: none;
+    }
+    .sidebar-backdrop {
+        display: none !important;
+    }
+    .main-content {
+        margin-left: 260px;
+    }
+}


### PR DESCRIPTION
## Summary
- implementa sidebar compartilhada com suporte responsivo e navegação acessível nas páginas do operador
- adiciona contadores em tempo real de tarefas e ordens e indicador de agenda com Firestore
- remove barras laterais antigas e atualiza scripts de páginas
- ajusta tamanho do logo e torna o toggle móvel independente do Firestore

## Testing
- `npm test` *(falha: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a4ab6fca0832eb7b7af562b0ea2c8