### PR TITLE
Include operator tasks in sidebar

### DIFF
--- a/public/js/ui/sidebar.js
+++ b/public/js/ui/sidebar.js
@@ -9,6 +9,10 @@ import {
   Timestamp
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 
+const API_BASE = window.location.hostname === 'localhost'
+  ? ''
+  : 'https://us-central1-app-organia.cloudfunctions.net';
+
 document.addEventListener('DOMContentLoaded', () => {
   const sidebar = document.getElementById('sidebar');
   const toggle = document.getElementById('sidebarToggle');
@@ -50,6 +54,18 @@ document.addEventListener('DOMContentLoaded', () => {
       tasksBadge.textContent = count;
       tasksBadge.classList.toggle('show', count > 0);
     });
+  }
+
+  // Lista de tarefas na sidebar
+  const sidebarTasks = document.getElementById('sidebarTasks');
+  if (sidebarTasks) {
+    fetch(`${API_BASE}/api/tarefas`)
+      .then(res => res.json())
+      .then(tasks => {
+        sidebarTasks.innerHTML = tasks.map(t => `<a href="operador-tarefas.html#${t.id || ''}" class="sidebar-sublink">${t.talhao || t.tipo || t.id}</a>`).join('');
+        sidebarTasks.classList.toggle('show', tasks.length > 0);
+      })
+      .catch(() => sidebarTasks.classList.remove('show'));
   }
 
   // Badges: ordens abertas

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -31,6 +31,7 @@
     <nav class="sidebar-nav">
       <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
       <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <div id="sidebarTasks" class="sidebar-submenu"></div>
       <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-clipboard-list"></i><span>Ordens</span><span id="ordersBadge" class="sidebar-badge"></span></a>
       <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
       <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>

--- a/public/style.css
+++ b/public/style.css
@@ -484,6 +484,32 @@ button:active, .btn:active {
     display: inline-block;
 }
 
+.sidebar-submenu {
+    display: none;
+    flex-direction: column;
+    margin-left: 24px;
+    margin-top: 4px;
+}
+
+.sidebar-submenu.show {
+    display: flex;
+}
+
+.sidebar-sublink {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    color: #1F2937;
+    text-decoration: none;
+    font-size: 14px;
+}
+
+.sidebar-sublink:hover {
+    background: #F3F4F6;
+}
+
 .sidebar-indicator {
     margin-left: auto;
     width: 8px;


### PR DESCRIPTION
## Summary
- show operator tasks inside "Tarefas" sidebar menu
- add styles for sidebar task list
- fetch tasks from API in sidebar

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b20b4425c832ea7754106efe216a5