### PR TITLE
Load operator tasks from Firestore

### DIFF
--- a/public/js/pages/operador-tarefas.js
+++ b/public/js/pages/operador-tarefas.js
@@ -1,51 +1,79 @@
 // public/js/pages/operador-tarefas.js
 
-const API_BASE = window.location.hostname === 'localhost'
-  ? ''
-  : 'https://us-central1-app-organia.cloudfunctions.net';
+import { db } from '../config/firebase.js';
+import {
+  collection,
+  onSnapshot,
+  doc,
+  getDoc
+} from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 
-export function initOperadorTarefas(userId, userRole) {
+const state = { farmClientId: null };
+
+export async function initOperadorTarefas(userId, userRole) {
+  await loadFarmId(userId);
   loadTasks();
   bindUI();
 }
 
-async function loadTasks() {
+async function loadFarmId(userId) {
   try {
-    const res = await fetch(`${API_BASE}/api/tarefas`);
-    const data = await res.json();
-    renderList(Array.isArray(data) ? data : []);
+    const snap = await getDoc(doc(db, 'users', userId));
+    state.farmClientId = snap.data()?.farmClientId || null;
   } catch (e) {
-    console.error(e);
-    renderList([]);
+    console.error('Erro ao obter farmClientId do operador', e);
   }
 }
 
+function loadTasks() {
+  if (!state.farmClientId) {
+    renderList([]);
+    return;
+  }
+  const q = collection(db, 'clients', state.farmClientId, 'tasks');
+  onSnapshot(
+    q,
+    snap => {
+      const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      renderList(data);
+    },
+    err => {
+      console.error('Erro ao carregar tarefas', err);
+      renderList([]);
+    }
+  );
+}
+
 function renderList(tasks) {
-const tbody = document.getElementById('tasksList');
+  const tbody = document.getElementById('tasksList');
   if (!tbody) return;
   tbody.innerHTML = '';
+  const now = new Date();
   tasks.forEach(t => {
     const tr = document.createElement('tr');
     tr.className = 'hover:bg-gray-50';
 
     const tdTalhao = document.createElement('td');
     tdTalhao.className = 'px-4 py-2';
-    tdTalhao.textContent = t.talhao || '-';
+    tdTalhao.textContent = t.plotName || t.talhao || '-';
 
     const tdTipo = document.createElement('td');
     tdTipo.className = 'px-4 py-2';
-    tdTipo.textContent = t.tipo || t.id;
+    tdTipo.textContent = t.title || t.tipo || t.id;
 
     const tdStatus = document.createElement('td');
     tdStatus.className = 'px-4 py-2';
-    tdStatus.textContent = t.status || '';
+    let statusText = 'Pendente';
+    if (t.isCompleted) statusText = 'Concluída';
+    else if (t.dueDate && new Date(t.dueDate) < now) statusText = 'Atrasada';
+    tdStatus.textContent = statusText;
 
     const tdAction = document.createElement('td');
     tdAction.className = 'px-4 py-2 text-right';
     const btn = document.createElement('button');
     btn.className = 'bg-green-600 text-white text-sm px-3 py-1 rounded hover:bg-green-700 transition';
     btn.textContent = 'Detalhes';
-    btn.addEventListener('click', () => openTaskModal(t));
+    btn.addEventListener('click', () => openTaskModal({ ...t, status: statusText }));
     tdAction.appendChild(btn);
 
     tr.appendChild(tdTalhao);
@@ -69,11 +97,13 @@ function openTaskModal(task) {
   const modal = document.getElementById('taskModal');
   const content = document.getElementById('taskModalContent');
   if (!modal || !content) return;
+  const due = task.dueDate ? new Date(task.dueDate).toLocaleDateString('pt-BR') : '-';
   content.innerHTML = `
-    <p><strong>Talhão:</strong> ${task.talhao || '-'}</p>
-    <p><strong>Tipo:</strong> ${task.tipo || '-'}</p>
+    <p><strong>Título:</strong> ${task.title || '-'}</p>
+    <p><strong>Talhão:</strong> ${task.plotName || '-'}</p>
+    <p><strong>Data:</strong> ${due}</p>
     <p><strong>Status:</strong> ${task.status || '-'}</p>
-    <p><strong>Descrição:</strong> ${task.descricao || task.description || 'Sem descrição'}</p>
+    <p><strong>Descrição:</strong> ${task.description || 'Sem descrição'}</p>
   `;
   modal.classList.remove('hidden');
 }


### PR DESCRIPTION
## Summary
- Load all operator property tasks from the client's Firestore subcollection and display them on the operator tasks page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd public && npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_689b3156e3ec832eb088baf6988292ae