### PR TITLE
feat: redesenhar dashboard do operador

### DIFF
--- a/public/js/pages/operador-dashboard.js
+++ b/public/js/pages/operador-dashboard.js
@@ -125,24 +125,25 @@ function renderTable() {
     empty?.classList.add('hidden');
     }
 
-   const now = new Date();
-    pageItems.forEach(t => {
-      const due = new Date(t.dueDate);
-      const statusHtml = t.isCompleted
-        ? '<span class="text-green-600">Concluída</span>'
-        : (due < now
-            ? '<span class="text-red-600">Atrasada</span>'
-            : '<span class="text-yellow-600">Pendente</span>');
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td class="px-3 py-2">${t.title || t.description || '(Sem título)'}</td>
-        <td class="px-3 py-2">${t.plotName || t.talhao || t.plotId || '-'}</td>
-        <td class="px-3 py-2">${formatDate(t.dueDate)}</td>
-        <td class="px-3 py-2">${statusHtml}</td>
-        <td class="px-3 py-2">${!t.isCompleted ? `<button class="concluir-btn px-2 py-1 bg-green-500 text-white rounded" data-id="${t.id}">Concluir</button>` : ''}</td>
-      `;
-      tbody.appendChild(tr);
-    });
+  const now = new Date();
+  pageItems.forEach(t => {
+    const due = new Date(t.dueDate);
+    const statusHtml = t.isCompleted
+      ? '<span class="status-pill completed">Concluída</span>'
+      : (due < now
+          ? '<span class="status-pill delayed">Atrasada</span>'
+          : '<span class="status-pill pending">Pendente</span>');
+    const tr = document.createElement('tr');
+    tr.className = 'border-b border-gray-200 hover:bg-gray-50';
+    tr.innerHTML = `
+      <td class="px-3 py-3 max-w-[160px] truncate">${t.title || t.description || '(Sem título)'}</td>
+      <td class="px-3 py-3 max-w-[160px] truncate">${t.plotName || t.talhao || t.plotId || '-'}</td>
+      <td class="px-3 py-3">${formatDate(t.dueDate)}</td>
+      <td class="px-3 py-3">${statusHtml}</td>
+      <td class="px-3 py-3">${!t.isCompleted ? `<button class="concluir-btn px-2 py-1 text-sm text-green-700 border border-green-700 rounded hover:bg-green-700 hover:text-white" data-id="${t.id}">Concluir</button>` : ''}</td>
+    `;
+    tbody.appendChild(tr);
+  });
 
   // Botões de concluir tarefa
   tbody.querySelectorAll('.concluir-btn').forEach(btn => {
@@ -178,11 +179,17 @@ function renderMetrics() {
     const monthCompletedEl = document.getElementById('monthCompleted');
     const monthNewEl = document.getElementById('monthNew');
 
-    if (totalPendingEl) totalPendingEl.textContent = pending;
-    if (totalDelayedEl) totalDelayedEl.textContent = delayed;
-    if (totalCompletedEl) totalCompletedEl.textContent = completed;
-    if (monthCompletedEl) monthCompletedEl.textContent = monthCompleted;
-    if (monthNewEl) monthNewEl.textContent = monthNew;
+    const setValue = (el, value) => {
+      if (!el) return;
+      el.textContent = value;
+      el.classList.remove('skeleton');
+    };
+
+    setValue(totalPendingEl, pending);
+    setValue(totalDelayedEl, delayed);
+    setValue(totalCompletedEl, completed);
+    setValue(monthCompletedEl, monthCompleted);
+    setValue(monthNewEl, monthNew);
   }
 
   function renderChart() {
@@ -192,16 +199,21 @@ function renderMetrics() {
     const pendentes = state.allTasks.filter(t => !t.isCompleted && new Date(t.dueDate) >= now).length;
     const concluidas = state.allTasks.filter(t => t.isCompleted).length;
     const atrasadas = state.allTasks.filter(t => !t.isCompleted && new Date(t.dueDate) < now).length;
+    const colors = ['#FEF08A', '#86EFAC', '#FCA5A5'];
     if (state.chart) {
       state.chart.data.labels = ['Pendentes', 'Concluídas', 'Atrasadas'];
       state.chart.data.datasets[0].data = [pendentes, concluidas, atrasadas];
+      state.chart.data.datasets[0].backgroundColor = colors;
       state.chart.update();
     } else {
       state.chart = new Chart(ctx, {
         type: 'pie',
         data: {
           labels: ['Pendentes', 'Concluídas', 'Atrasadas'],
-          datasets: [{ data: [pendentes, concluidas, atrasadas] }]
+          datasets: [{
+            data: [pendentes, concluidas, atrasadas],
+            backgroundColor: colors
+          }]
         },
         options: { responsive: true }
       });

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -15,7 +15,7 @@
 
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="min-h-screen bg-gray-100 text-gray-800">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="operador-dashboard-marker" class="hidden"></div>
 
   <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
@@ -38,52 +38,44 @@
   </aside>
 
   <main class="main-content">
-    <header class="dashboard-header shadow-md">
+    <header class="dashboard-header">
       <div class="dashboard-container flex justify-between items-center h-16">
-        <div class="flex items-center space-x-4">
-          <img src="logo.png" alt="Orgânia" class="dashboard-logo" />
-          <h1 class="text-2xl font-semibold">Dashboard do Operador</h1>
-        </div>
-        <button id="logoutBtn" class="dashboard-btn flex items-center text-sm"><i class="fas fa-sign-out-alt mr-2"></i>Sair</button>
+        <h1 class="text-lg font-semibold">Dashboard do Operador</h1>
+        <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
       </div>
     </header>
 
     <!-- CONTEÚDO PRINCIPAL -->
-    <div class="dashboard-container flex flex-col py-6">
+    <div class="dashboard-container flex flex-col pt-4 pb-6">
 
-    <!-- MÉTRICAS DO MÊS -->
-    <section class="dashboard-section grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+    <!-- KPIS -->
+    <section class="dashboard-section grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
       <div class="dashboard-card text-center">
-        <p class="text-sm text-gray-500">Concluídas este mês</p>
-        <p id="monthCompleted" class="text-2xl font-bold">0</p>
+        <p class="text-xs text-gray-500">Concluídas mês</p>
+        <p id="monthCompleted" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
       </div>
       <div class="dashboard-card text-center">
-        <p class="text-sm text-gray-500">Novas este mês</p>
-        <p id="monthNew" class="text-2xl font-bold">0</p>
+        <p class="text-xs text-gray-500">Novas mês</p>
+        <p id="monthNew" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
+      </div>
+      <div class="dashboard-card text-center">
+        <p class="text-xs text-gray-500">Pendentes</p>
+        <p id="totalPending" class="kpi-value skeleton text-[28px] font-bold text-[#92400E]"></p>
+      </div>
+      <div class="dashboard-card text-center">
+        <p class="text-xs text-gray-500">Atrasadas</p>
+        <p id="totalDelayed" class="kpi-value skeleton text-[28px] font-bold text-[#991B1B]"></p>
+      </div>
+      <div class="dashboard-card text-center">
+        <p class="text-xs text-gray-500">Concluídas</p>
+        <p id="totalCompleted" class="kpi-value skeleton text-[28px] font-bold text-[#166534]"></p>
       </div>
     </section>
 
-    <!-- MÉTRICAS GERAIS -->
-    <section class="dashboard-section grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-      <div class="dashboard-card text-center">
-        <p class="text-sm text-gray-500">Pendentes</p>
-        <p id="totalPending" class="text-2xl font-bold">0</p>
-      </div>
-      <div class="dashboard-card text-center">
-        <p class="text-sm text-gray-500">Atrasadas</p>
-        <p id="totalDelayed" class="text-2xl font-bold">0</p>
-      </div>
-      <div class="dashboard-card text-center">
-        <p class="text-sm text-gray-500">Concluídas</p>
-        <p id="totalCompleted" class="text-2xl font-bold">0</p>
-      </div>
-    </section>
-
- <!-- CONTROLE: NOVA TAREFA -->
-    <div class="dashboard-section flex justify-end mb-4">
-         <button id="createTaskBtn"
-              class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 transition">
-        <i class="fas fa-plus mr-2"></i>Nova Tarefa
+    <!-- CONTROLE: NOVA TAREFA -->
+    <div class="dashboard-section flex justify-end mt-2 mb-4">
+         <button id="createTaskBtn" class="flex items-center gap-2 bg-green-600 text-white px-4 h-11 rounded hover:bg-green-700 transition">
+        <i class="fas fa-plus"></i><span>Nova Tarefa</span>
       </button>
     </div>
 
@@ -91,19 +83,19 @@
     <section class="dashboard-section grid grid-cols-1 lg:grid-cols-2 gap-6 flex-1">
       <!-- GRÁFICO -->
       <section class="dashboard-card flex flex-col p-5">
-        <h3 class="text-lg font-medium mb-4">Resumo de Tarefas</h3>
+        <h3 class="text-lg font-semibold mb-4">Resumo de Tarefas</h3>
         <div class="flex-1 flex items-center justify-center">
-<canvas id="tasksChart" class="w-full max-w-sm h-48"></canvas>
+          <canvas id="tasksChart" class="w-full max-w-sm h-48"></canvas>
         </div>
       </section>
 
       <!-- TABELA -->
       <section class="dashboard-card flex flex-col p-5">
-<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 space-y-2 sm:space-y-0">
-          <h3 class="text-lg font-medium">Tarefas</h3>
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 space-y-2 sm:space-y-0">
+          <h3 class="text-lg font-semibold">Tarefas</h3>
           <div>
-            <label for="filterSelect" class="mr-2 font-medium">Filtrar:</label>
-            <select id="filterSelect" class="border rounded p-1">
+            <label for="filterSelect" class="mr-2 text-sm text-gray-700">Filtrar:</label>
+            <select id="filterSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2">
               <option value="todas">Todas</option>
               <option value="pendentes">Pendentes</option>
               <option value="concluidas">Concluídas</option>
@@ -111,15 +103,15 @@
             </select>
           </div>
         </div>
-                <div class="overflow-auto">
+        <div class="overflow-auto">
           <table class="min-w-full text-left text-sm">
             <thead class="bg-gray-50">
               <tr>
-                <th class="px-3 py-2">Título</th>
-                <th class="px-3 py-2">Talhão</th>
-                <th class="px-3 py-2">Data</th>
-                <th class="px-3 py-2">Status</th>
-                <th class="px-3 py-2">Ações</th>
+                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Título</th>
+                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Talhão</th>
+                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Data</th>
+                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Status</th>
+                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Ações</th>
               </tr>
             </thead>
             <tbody id="tasksTableBody"></tbody>

--- a/public/style.css
+++ b/public/style.css
@@ -342,38 +342,43 @@ button:active, .btn:active {
 =================================================================== */
 
 .dashboard-header {
-    background-color: var(--brand-green);
-    color: white;
-}
-
-.dashboard-header a,
-.dashboard-header h1 {
-    color: inherit;
+    background-color: #FFFFFF;
+    border-bottom: 1px solid #E5E7EB;
+    box-shadow: 0 1px 0 rgba(0,0,0,0.02);
+    color: #1F2937;
 }
 
 .dashboard-btn {
-    background-color: white;
-    color: var(--brand-green);
-    padding: 0.5rem 1rem;
-    border-radius: 0.375rem;
+    background: transparent;
+    border: 1px solid #E5E7EB;
+    color: #1F2937;
+    padding: 0 1rem;
+    height: 40px;
+    border-radius: 8px;
     font-weight: 600;
     transition: background-color 0.2s;
 }
 
 .dashboard-btn:hover {
-    background-color: #e6f4ea;
+    background-color: #F3F4F6;
 }
 
 .dashboard-container {
     max-width: 1280px;
     margin: 0 auto;
-    padding: 1.5rem;
+    padding: 1rem;
+}
+
+@media (min-width: 640px) {
+    .dashboard-container {
+        padding: 1.5rem;
+    }
 }
 
 .dashboard-card {
     background-color: var(--card-background);
     border: 1px solid #e2e8f0;
-    border-radius: 0.5rem;
+    border-radius: 0.75rem;
     padding: 1rem;
     box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
@@ -564,4 +569,47 @@ button:active, .btn:active {
     .main-content {
         margin-left: 260px;
     }
+}
+
+/* Status pills */
+.status-pill {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 9999px;
+}
+
+.status-pill.pending {
+    background: #FEF08A;
+    color: #92400E;
+}
+
+.status-pill.delayed {
+    background: #FCA5A5;
+    color: #991B1B;
+}
+
+.status-pill.completed {
+    background: #86EFAC;
+    color: #166534;
+}
+
+.status-pill.default {
+    background: #E5E7EB;
+    color: #1F2937;
+}
+
+/* Simple skeleton loader */
+.skeleton {
+    background: #E5E7EB;
+    border-radius: 4px;
+    display: inline-block;
+    height: 24px;
+    width: 64px;
+    animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
 }


### PR DESCRIPTION
## Summary
- redesenha header e sidebar do dashboard do operador
- cria cards de KPI com skeleton e cores por status
- aplica estilos ao gráfico, tabela de tarefas e botão de nova tarefa

## Testing
- `npm test` *(erro: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b3d317a34832e870158db87fd8951