### PR TITLE
refactor: refresh operator dashboard layout

### DIFF
--- a/public/js/pages/operador-dashboard.js
+++ b/public/js/pages/operador-dashboard.js
@@ -128,19 +128,16 @@ function renderTable() {
   const now = new Date();
   pageItems.forEach(t => {
     const due = new Date(t.dueDate);
-    const statusHtml = t.isCompleted
-      ? '<span class="status-pill completed">Concluída</span>'
-      : (due < now
-          ? '<span class="status-pill delayed">Atrasada</span>'
-          : '<span class="status-pill pending">Pendente</span>');
+    const status = t.isCompleted ? 'Concluída' : (due < now ? 'Atrasada' : 'Pendente');
+    const statusHtml = createStatusPill(status);
     const tr = document.createElement('tr');
-    tr.className = 'border-b border-gray-200 hover:bg-gray-50';
+    tr.className = 'border-b border-gray-200 hover:bg-gray-100';
     tr.innerHTML = `
-      <td class="px-3 py-3 max-w-[160px] truncate">${t.title || t.description || '(Sem título)'}</td>
-      <td class="px-3 py-3 max-w-[160px] truncate">${t.plotName || t.talhao || t.plotId || '-'}</td>
-      <td class="px-3 py-3">${formatDate(t.dueDate)}</td>
-      <td class="px-3 py-3">${statusHtml}</td>
-      <td class="px-3 py-3">${!t.isCompleted ? `<button class="concluir-btn px-2 py-1 text-sm text-green-700 border border-green-700 rounded hover:bg-green-700 hover:text-white" data-id="${t.id}">Concluir</button>` : ''}</td>
+      <td class="px-3 py-3 h-12 max-w-[160px] truncate">${t.title || t.description || '(Sem título)'}</td>
+      <td class="px-3 py-3 h-12 max-w-[160px] truncate">${t.plotName || t.talhao || t.plotId || '-'}</td>
+      <td class="px-3 py-3 h-12">${formatDate(t.dueDate)}</td>
+      <td class="px-3 py-3 h-12">${statusHtml}</td>
+      <td class="px-3 py-3 h-12">${!t.isCompleted ? `<button class="concluir-btn px-2 py-1 text-sm text-green-700 border border-green-700 rounded hover:bg-green-700 hover:text-white" data-id="${t.id}">Concluir</button>` : ''}</td>
     `;
     tbody.appendChild(tr);
   });
@@ -217,8 +214,29 @@ function renderMetrics() {
         },
         options: { responsive: true }
       });
-    }
   }
+}
+
+function normalizeStatus(str) {
+  return (str || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+function createStatusPill(status) {
+  const normalized = normalizeStatus(status);
+  if (normalized === 'concluida') {
+    return '<span class="status-pill completed">Concluída</span>';
+  }
+  if (normalized === 'atrasada') {
+    return '<span class="status-pill delayed">Atrasada</span>';
+  }
+  if (normalized === 'pendente') {
+    return '<span class="status-pill pending">Pendente</span>';
+  }
+  return `<span class="status-pill default">${status}</span>`;
+}
 
 function formatDate(date) {
   if (!date) return '-';

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -39,7 +39,7 @@
 
   <main class="main-content">
     <header class="dashboard-header">
-      <div class="dashboard-container flex justify-between items-center h-16">
+      <div class="dashboard-container flex justify-between items-center">
         <h1 class="text-lg font-semibold">Dashboard do Operador</h1>
         <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
       </div>
@@ -49,7 +49,7 @@
     <div class="dashboard-container flex flex-col pt-4 pb-6">
 
     <!-- KPIS -->
-    <section class="dashboard-section grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+    <section class="dashboard-section grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-6 kpi-grid">
       <div class="dashboard-card text-center">
         <p class="text-xs text-gray-500">Concluídas mês</p>
         <p id="monthCompleted" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
@@ -62,11 +62,11 @@
         <p class="text-xs text-gray-500">Pendentes</p>
         <p id="totalPending" class="kpi-value skeleton text-[28px] font-bold text-[#92400E]"></p>
       </div>
-      <div class="dashboard-card text-center">
+      <div class="dashboard-card text-center lg:col-span-2">
         <p class="text-xs text-gray-500">Atrasadas</p>
         <p id="totalDelayed" class="kpi-value skeleton text-[28px] font-bold text-[#991B1B]"></p>
       </div>
-      <div class="dashboard-card text-center">
+      <div class="dashboard-card text-center lg:col-span-2">
         <p class="text-xs text-gray-500">Concluídas</p>
         <p id="totalCompleted" class="kpi-value skeleton text-[28px] font-bold text-[#166534]"></p>
       </div>
@@ -74,9 +74,9 @@
 
     <!-- CONTROLE: NOVA TAREFA -->
     <div class="dashboard-section flex justify-end mt-2 mb-4">
-         <button id="createTaskBtn" class="flex items-center gap-2 bg-green-600 text-white px-4 h-11 rounded hover:bg-green-700 transition">
-        <i class="fas fa-plus"></i><span>Nova Tarefa</span>
-      </button>
+         <button id="createTaskBtn" class="flex items-center gap-2 bg-[#6C9F3D] text-white px-4 h-11 rounded hover:bg-[#5A8733] transition">
+         <i class="fas fa-plus"></i><span>Nova Tarefa</span>
+       </button>
     </div>
 
     <!-- GRADE: GRÁFICO E TABELA -->
@@ -95,7 +95,7 @@
           <h3 class="text-lg font-semibold">Tarefas</h3>
           <div>
             <label for="filterSelect" class="mr-2 text-sm text-gray-700">Filtrar:</label>
-            <select id="filterSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2">
+            <select id="filterSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none">
               <option value="todas">Todas</option>
               <option value="pendentes">Pendentes</option>
               <option value="concluidas">Concluídas</option>
@@ -107,11 +107,11 @@
           <table class="min-w-full text-left text-sm">
             <thead class="bg-gray-50">
               <tr>
-                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Título</th>
-                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Talhão</th>
-                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Data</th>
-                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Status</th>
-                <th scope="col" class="px-3 py-3 text-xs font-semibold text-gray-700">Ações</th>
+                <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Título</th>
+                <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Talhão</th>
+                <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Data</th>
+                <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Status</th>
+                <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Ações</th>
               </tr>
             </thead>
             <tbody id="tasksTableBody"></tbody>

--- a/public/style.css
+++ b/public/style.css
@@ -76,14 +76,15 @@ letter-spacing: normal;
     z-index: 0;
 }
 
-/* Estilo de foco para inputs, usando a cor da marca */
-input:focus, select:focus, textarea:focus {
+/* Estilo de foco visível para elementos interativos */
+input:focus,
+select:focus,
+textarea:focus,
+button:focus,
+a:focus {
     outline: none;
-    --tw-ring-color: var(--brand-green);
-    --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-    --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-    box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-    border-color: var(--brand-green) !important;
+    box-shadow: 0 0 0 3px rgba(108,159,61,0.30);
+    border-color: #6C9F3D !important;
 }
 
 /* Estilo para o botão de filtro ativo */
@@ -346,6 +347,9 @@ button:active, .btn:active {
     border-bottom: 1px solid #E5E7EB;
     box-shadow: 0 1px 0 rgba(0,0,0,0.02);
     color: #1F2937;
+    height: 64px;
+    display: flex;
+    align-items: center;
 }
 
 .dashboard-btn {
@@ -376,11 +380,11 @@ button:active, .btn:active {
 }
 
 .dashboard-card {
-    background-color: var(--card-background);
-    border: 1px solid #e2e8f0;
-    border-radius: 0.75rem;
-    padding: 1rem;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    background-color: #FFFFFF;
+    border: 1px solid #E5E7EB;
+    border-radius: 0.75rem; /* 12px */
+    padding: 1.25rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 
 /* Elementos comuns entre os dashboards */
@@ -577,26 +581,33 @@ button:active, .btn:active {
     font-weight: 600;
     padding: 2px 8px;
     border-radius: 9999px;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid transparent;
 }
 
 .status-pill.pending {
-    background: #FEF08A;
-    color: #92400E;
+    background: #FEF9C3;
+    color: #854D0E;
+    border-color: #FEF08A;
 }
 
 .status-pill.delayed {
-    background: #FCA5A5;
+    background: #FEE2E2;
     color: #991B1B;
+    border-color: #FECACA;
 }
 
 .status-pill.completed {
-    background: #86EFAC;
+    background: #DCFCE7;
     color: #166534;
+    border-color: #BBF7D0;
 }
 
 .status-pill.default {
     background: #E5E7EB;
     color: #1F2937;
+    border-color: #D1D5DB;
 }
 
 /* Simple skeleton loader */


### PR DESCRIPTION
## Summary
- restyle operator dashboard header and container
- add responsive KPI grid and button styles
- show task statuses with accessible colored pills

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b429639a8832ea36f101111d08ac0