### PR TITLE
Adjust operator dashboard layout and styling

### DIFF
--- a/public/js/pages/operador-dashboard.js
+++ b/public/js/pages/operador-dashboard.js
@@ -201,6 +201,8 @@ function renderMetrics() {
       state.chart.data.labels = ['Pendentes', 'Concluídas', 'Atrasadas'];
       state.chart.data.datasets[0].data = [pendentes, concluidas, atrasadas];
       state.chart.data.datasets[0].backgroundColor = colors;
+      state.chart.data.datasets[0].borderColor = '#ffffff';
+      state.chart.data.datasets[0].borderWidth = 2;
       state.chart.update();
     } else {
       state.chart = new Chart(ctx, {
@@ -209,10 +211,24 @@ function renderMetrics() {
           labels: ['Pendentes', 'Concluídas', 'Atrasadas'],
           datasets: [{
             data: [pendentes, concluidas, atrasadas],
-            backgroundColor: colors
+            backgroundColor: colors,
+            borderColor: '#ffffff',
+            borderWidth: 2
           }]
         },
-        options: { responsive: true }
+        options: {
+          responsive: true,
+          plugins: {
+            legend: {
+              position: 'top',
+              labels: {
+                font: { size: 12 },
+                color: '#6B7280',
+                padding: 8
+              }
+            }
+          }
+        }
       });
   }
 }

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -49,7 +49,7 @@
     <div class="dashboard-container flex flex-col pt-4 pb-6">
 
     <!-- KPIS -->
-    <section class="dashboard-section grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-6 kpi-grid">
+    <section class="dashboard-section grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6 kpi-grid">
       <div class="dashboard-card text-center">
         <p class="text-xs text-gray-500">Concluídas mês</p>
         <p id="monthCompleted" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
@@ -62,11 +62,11 @@
         <p class="text-xs text-gray-500">Pendentes</p>
         <p id="totalPending" class="kpi-value skeleton text-[28px] font-bold text-[#92400E]"></p>
       </div>
-      <div class="dashboard-card text-center lg:col-span-2">
+      <div class="dashboard-card text-center">
         <p class="text-xs text-gray-500">Atrasadas</p>
         <p id="totalDelayed" class="kpi-value skeleton text-[28px] font-bold text-[#991B1B]"></p>
       </div>
-      <div class="dashboard-card text-center lg:col-span-2">
+      <div class="dashboard-card text-center">
         <p class="text-xs text-gray-500">Concluídas</p>
         <p id="totalCompleted" class="kpi-value skeleton text-[28px] font-bold text-[#166534]"></p>
       </div>
@@ -91,9 +91,9 @@
 
       <!-- TABELA -->
       <section class="dashboard-card flex flex-col p-5">
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 space-y-2 sm:space-y-0">
+        <div class="flex items-start justify-between mb-4">
           <h3 class="text-lg font-semibold">Tarefas</h3>
-          <div>
+          <div class="flex items-center">
             <label for="filterSelect" class="mr-2 text-sm text-gray-700">Filtrar:</label>
             <select id="filterSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none">
               <option value="todas">Todas</option>

--- a/public/style.css
+++ b/public/style.css
@@ -368,7 +368,7 @@ button:active, .btn:active {
 }
 
 .dashboard-container {
-    max-width: 1280px;
+    max-width: 1240px;
     margin: 0 auto;
     padding: 1rem;
 }
@@ -385,6 +385,10 @@ button:active, .btn:active {
     border-radius: 0.75rem; /* 12px */
     padding: 1.25rem;
     box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+.kpi-grid .dashboard-card {
+    min-height: 112px;
 }
 
 /* Elementos comuns entre os dashboards */
@@ -584,6 +588,8 @@ button:active, .btn:active {
     display: inline-flex;
     align-items: center;
     border: 1px solid transparent;
+    white-space: nowrap;
+    width: auto;
 }
 
 .status-pill.pending {


### PR DESCRIPTION
## Summary
- constrain dashboard container to 1240px and even out KPI cards
- refine tasks chart legend and status pills
- align filter control and update KPI grid to three-by-two layout

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_689b4868ebc8832ea3f0b4321a96b130