### PR TITLE
Refatorar layout do dashboard do operador

### DIFF
--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -80,7 +80,7 @@
     </div>
 
     <!-- GRADE: GRÁFICOS -->
-    <section class="dashboard-section grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+    <section id="dash-graphs-row" class="dashboard-section grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
       <!-- GRÁFICO -->
       <section class="dashboard-card flex flex-col p-5">
         <h3 class="text-lg font-semibold mb-4">Resumo de Tarefas</h3>
@@ -101,7 +101,7 @@
     </section>
 
     <!-- TABELA -->
-    <section class="dashboard-section flex-1">
+    <section id="dash-table-row" class="dashboard-section w-full">
       <section class="dashboard-card flex flex-col p-5">
         <div class="flex items-start justify-between mb-4">
           <h3 class="text-lg font-semibold">Tarefas</h3>

--- a/public/style.css
+++ b/public/style.css
@@ -404,6 +404,23 @@ button:active, .btn:active {
     margin-bottom: 1rem;
 }
 
+/* Dashboard rows layout */
+#dash-graphs-row {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 1024px) {
+    #dash-graphs-row {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+#dash-table-row {
+    width: 100%;
+}
+
 @media (prefers-reduced-motion: reduce) {
     * {
         animation: none !important;


### PR DESCRIPTION
## Summary
- Agrupa "Resumo de Tarefas" e "Vencem nos próximos 7 dias" em `dash-graphs-row` com grid responsivo
- Move a tabela de tarefas para `dash-table-row`, ocupando 100% da largura
- Adiciona regras de estilo para os novos wrappers

## Testing
- `npm test` (script ausente)
- `(cd public && npm test)` (Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689b67c32e88832e9bb640974cde5388