### PR TITLE
Fix dashboard graph overflow

### DIFF
--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -93,25 +93,25 @@
     </section>
 
     <!-- GRADE: GRÁFICOS -->
-    <section id="dash-graphs-row" class="dashboard-section grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+    <section id="dash-graphs-row" class="dashboard-section mb-6">
       <!-- GRÁFICO -->
-      <section class="dashboard-card flex flex-col p-5">
+      <section class="dashboard-card flex flex-col p-5 min-w-0">
         <h3 class="text-lg font-semibold mb-4">Resumo de Tarefas</h3>
-        <div class="flex items-center justify-center h-[260px] sm:h-[300px]">
+        <div class="flex items-center justify-center w-full h-[260px] sm:h-[300px]">
           <canvas id="tasksChart" class="w-full h-full"></canvas>
         </div>
       </section>
 
       <!-- CARD 7 DIAS -->
-      <section id="card-7dias" class="dashboard-card flex flex-col p-5">
+      <section id="card-7dias" class="dashboard-card flex flex-col p-5 min-w-0">
         <h3 class="text-lg font-semibold">Vencem nos próximos 7 dias</h3>
         <p class="text-xs text-gray-500 mb-4">Somente Pendentes e Atrasadas</p>
-        <div id="card-7dias-loading" class="flex items-center justify-center h-[260px] sm:h-[300px]">Carregando...</div>
-        <div id="card-7dias-empty" class="hidden flex flex-col items-center justify-center gap-2 text-center text-gray-500 text-[13px] h-[260px] sm:h-[300px]">
+        <div id="card-7dias-loading" class="flex items-center justify-center w-full h-[280px] sm:h-[300px]">Carregando...</div>
+        <div id="card-7dias-empty" class="hidden flex flex-col items-center justify-center gap-2 text-center text-gray-500 text-[13px] w-full h-[280px] sm:h-[300px]">
           <i class="fas fa-calendar-check text-xl"></i>
           <span>Nada vencendo nos próximos 7 dias</span>
         </div>
-        <div id="card-7dias-chart" class="flex items-center justify-center h-[260px] sm:h-[300px]">
+        <div id="card-7dias-chart" class="flex items-center justify-center w-full h-[280px] sm:h-[300px] max-w-full">
           <canvas id="chart-7dias" class="w-full h-full hidden cursor-pointer"></canvas>
         </div>
       </section>

--- a/public/style.css
+++ b/public/style.css
@@ -385,6 +385,8 @@ button:active, .btn:active {
     border-radius: 0.75rem; /* 12px */
     padding: 1.25rem;
     box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    box-sizing: border-box;
+    max-width: 100%;
 }
 
 .kpi-grid .dashboard-card {
@@ -408,12 +410,13 @@ button:active, .btn:active {
 #dash-graphs-row {
     display: grid;
     gap: 1.5rem;
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
 }
 
 @media (min-width: 1024px) {
     #dash-graphs-row {
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent dashboard graph row cards from exceeding container width by using min-width and improved grid
- constrain 7-day chart container sizing and card box model

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b7c4a9bd8832e99e776818a983121