### PR TITLE
feat: consolidate operator task modal and comments

### DIFF
--- a/public/js/pages/operador-tarefas.js
+++ b/public/js/pages/operador-tarefas.js
@@ -7,13 +7,15 @@ import {
   doc,
   getDoc
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+import { initTaskModal, openTaskModal } from '../ui/task-modal.js';
 
 const state = { farmClientId: null };
 
 export async function initOperadorTarefas(userId, userRole) {
   await loadFarmId(userId);
+  window.taskModalFarmId = state.farmClientId;
+  initTaskModal();
   loadTasks();
-  bindUI();
 }
 
 async function loadFarmId(userId) {
@@ -73,11 +75,11 @@ function renderList(tasks) {
     tdStatus.textContent = statusText;
 
     const tdAction = document.createElement('td');
-    tdAction.className = 'px-4 py-2 text-right';
+    tdAction.className = 'px-4 py-2';
     const btn = document.createElement('button');
-    btn.className = 'bg-green-600 text-white text-sm px-3 py-1 rounded hover:bg-green-700 transition';
-    btn.textContent = 'Detalhes';
-    btn.addEventListener('click', () => openTaskModal({ ...t, status: statusText }));
+    btn.className = 'details-btn px-2 py-1 text-sm text-blue-700 border border-blue-700 rounded hover:bg-blue-700 hover:text-white flex items-center gap-1';
+    btn.innerHTML = '<i class="fas fa-eye"></i><span>Ver detalhes</span>';
+    btn.addEventListener('click', () => openTaskModal(t.id, 'table'));
     tdAction.appendChild(btn);
 
     tr.appendChild(tdTalhao);
@@ -89,31 +91,3 @@ function renderList(tasks) {
   });
 }
 
-function bindUI() {
-  const modal = document.getElementById('taskModal');
-  const closeModal = document.getElementById('closeTaskModal');
-  closeModal?.addEventListener('click', hideTaskModal);
-  modal?.addEventListener('click', (e) => {
-    if (e.target === modal) hideTaskModal();
-  });
-}
-
-function openTaskModal(task) {
-  const modal = document.getElementById('taskModal');
-  const content = document.getElementById('taskModalContent');
-  if (!modal || !content) return;
-  const due = task.dueDate ? new Date(task.dueDate).toLocaleDateString('pt-BR') : '-';
-  content.innerHTML = `
-    <p><strong>Título:</strong> ${task.title || '-'}</p>
-    <p><strong>Talhão:</strong> ${task.plotName || '-'}</p>
-    <p><strong>Vencimento:</strong> ${due}</p>
-    <p><strong>Status:</strong> ${task.status || '-'}</p>
-    <p><strong>Descrição:</strong> ${task.description || 'Sem descrição'}</p>
-  `;
-  modal.classList.remove('hidden');
-}
-
-function hideTaskModal() {
-  const modal = document.getElementById('taskModal');
-  modal?.classList.add('hidden');
-}

--- a/public/js/ui/task-modal.js
+++ b/public/js/ui/task-modal.js
@@ -1,0 +1,219 @@
+import { db, auth } from '../config/firebase.js';
+import {
+  doc,
+  getDoc,
+  getDocs,
+  updateDoc,
+  addDoc,
+  collection,
+  query,
+  orderBy,
+  limit,
+  Timestamp
+} from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+
+let currentTaskId = null;
+let currentTaskRef = null;
+let original = null;
+let currentSource = null;
+
+export function initTaskModal() {
+  const modal = document.getElementById('task-modal');
+  if (!modal) return;
+  document.getElementById('btn-edit')?.addEventListener('click', enterEditMode);
+  document.getElementById('btn-save')?.addEventListener('click', saveTaskEdits);
+  document.getElementById('btn-close')?.addEventListener('click', () => {
+    modal.classList.add('hidden');
+    exitEditMode();
+  });
+  document.getElementById('btn-complete')?.addEventListener('click', completeTask);
+  document.getElementById('btn-add-comment')?.addEventListener('click', addComment);
+}
+
+export async function openTaskModal(taskId, source = 'table') {
+  const farmId = window.taskModalFarmId;
+  if (!farmId || !taskId) return;
+  currentTaskId = taskId;
+  currentSource = source;
+  currentTaskRef = doc(db, 'clients', farmId, 'tasks', taskId);
+  const snap = await getDoc(currentTaskRef);
+  if (!snap.exists()) return;
+  const data = snap.data();
+  original = {
+    titulo: data.title || '',
+    talhao: data.talhao || data.plotName || '',
+    vencimento: data.dueDate ? new Date(data.dueDate).toISOString().split('T')[0] : '',
+    descricao: data.description || ''
+  };
+  document.getElementById('task-titulo').value = original.titulo;
+  document.getElementById('task-talhao').value = original.talhao;
+  document.getElementById('task-vencimento').value = original.vencimento;
+  document.getElementById('task-desc').value = original.descricao;
+  exitEditMode();
+  await loadComments(currentTaskRef);
+  document.getElementById('task-modal').classList.remove('hidden');
+}
+
+export function enterEditMode() {
+  ['task-titulo', 'task-talhao', 'task-vencimento', 'task-desc'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.disabled = false;
+  });
+  document.getElementById('task-form')?.classList.remove('modal-read');
+  document.getElementById('btn-edit')?.classList.add('hidden');
+  document.getElementById('btn-save')?.classList.remove('hidden');
+  document.getElementById('btn-complete')?.classList.add('hidden');
+}
+
+export function exitEditMode() {
+  ['task-titulo', 'task-talhao', 'task-vencimento', 'task-desc'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.disabled = true;
+  });
+  document.getElementById('task-form')?.classList.add('modal-read');
+  document.getElementById('btn-edit')?.classList.remove('hidden');
+  document.getElementById('btn-save')?.classList.add('hidden');
+  document.getElementById('btn-complete')?.classList.remove('hidden');
+}
+
+export async function saveTaskEdits() {
+  if (!currentTaskRef || !original) return;
+  const titulo = document.getElementById('task-titulo').value.trim();
+  const talhao = document.getElementById('task-talhao').value.trim();
+  const vencimento = document.getElementById('task-vencimento').value;
+  const descricao = document.getElementById('task-desc').value.trim();
+  const changes = [];
+  const updates = {};
+  if (titulo !== original.titulo) {
+    changes.push({ campo: 'titulo', de: original.titulo, para: titulo });
+    updates.title = titulo;
+  }
+  if (talhao !== original.talhao) {
+    changes.push({ campo: 'talhao', de: original.talhao, para: talhao });
+    updates.talhao = talhao;
+    updates.plotName = talhao;
+  }
+  if (vencimento !== original.vencimento) {
+    changes.push({ campo: 'vencimento', de: formatDate(original.vencimento), para: formatDate(vencimento) });
+    updates.dueDate = vencimento;
+  }
+  if (descricao !== original.descricao) {
+    changes.push({ campo: 'descricao', de: original.descricao, para: descricao });
+    updates.description = descricao;
+  }
+  if (!changes.length) {
+    exitEditMode();
+    return;
+  }
+  await updateDoc(currentTaskRef, updates);
+  const user = auth.currentUser;
+  const autor = user?.displayName || user?.email || user?.uid || 'Anônimo';
+  const now = Timestamp.now();
+  const resumoParts = changes.map(ch => {
+    if (ch.campo === 'descricao') return 'Descrição: alterada';
+    if (ch.campo === 'vencimento') return `Vencimento: ${ch.de} → ${ch.para}`;
+    const cap = ch.campo.charAt(0).toUpperCase() + ch.campo.slice(1);
+    return `${cap}: "${ch.de}" → "${ch.para}"`;
+  });
+  const resumo = `✏️ Edição por ${autor} — ${formatDateTime(now)} • ${resumoParts.join(' • ')}`;
+  await addDoc(collection(currentTaskRef, 'comentarios'), {
+    tipo: 'edicao',
+    autorUid: user?.uid || '',
+    autorNome: autor,
+    criadoEm: now,
+    mudancas: changes,
+    resumo
+  });
+  original = { titulo, talhao, vencimento, descricao };
+  exitEditMode();
+  await loadComments(currentTaskRef);
+  if (currentSource === 'table') {
+    document.dispatchEvent(new CustomEvent('task-updated', { detail: { id: currentTaskId } }));
+  }
+}
+
+export async function completeTask() {
+  if (!currentTaskRef) return;
+  const user = auth.currentUser;
+  const autor = user?.displayName || user?.email || user?.uid || 'Anônimo';
+  const now = Timestamp.now();
+  const snap = await getDoc(currentTaskRef);
+  const data = snap.data() || {};
+  const updates = { status: 'Concluída', isCompleted: true };
+  if (!data.fim) updates.fim = now;
+  await updateDoc(currentTaskRef, updates);
+  await addDoc(collection(currentTaskRef, 'comentarios'), {
+    tipo: 'conclusao',
+    autorUid: user?.uid || '',
+    autorNome: autor,
+    criadoEm: now,
+    resumo: `✅ Concluída por ${autor} — ${formatDateTime(now)}`
+  });
+  document.getElementById('task-modal').classList.add('hidden');
+  exitEditMode();
+  if (currentSource === 'table') {
+    document.dispatchEvent(new CustomEvent('task-updated', { detail: { id: currentTaskId } }));
+  }
+}
+
+export async function addComment() {
+  if (!currentTaskRef) return;
+  const text = document.getElementById('comment-input').value.trim();
+  if (!text) return;
+  const user = auth.currentUser;
+  const autor = user?.displayName || user?.email || user?.uid || 'Anônimo';
+  const now = Timestamp.now();
+  await addDoc(collection(currentTaskRef, 'comentarios'), {
+    tipo: 'comentario',
+    autorUid: user?.uid || '',
+    autorNome: autor,
+    texto: text,
+    criadoEm: now
+  });
+  document.getElementById('comment-input').value = '';
+  await loadComments(currentTaskRef);
+}
+
+async function loadComments(taskRef) {
+  const list = document.getElementById('comments-list');
+  if (!list) return;
+  list.innerHTML = '';
+  const q = query(collection(taskRef, 'comentarios'), orderBy('criadoEm', 'desc'), limit(20));
+  const snap = await getDocs(q);
+  snap.forEach(c => {
+    const data = c.data();
+    const item = document.createElement('div');
+    item.className = 'comment-item';
+    const avatar = document.createElement('div');
+    avatar.className = 'comment-avatar';
+    avatar.textContent = (data.autorNome || '?').split(' ').map(n => n[0]).join('').substring(0,2).toUpperCase();
+    const content = document.createElement('div');
+    content.className = 'comment-content';
+    const meta = document.createElement('div');
+    meta.className = 'comment-meta';
+    meta.textContent = `${data.autorNome || 'Anônimo'} • ${formatDateTime(data.criadoEm)}`;
+    const text = document.createElement('p');
+    text.className = 'text-sm';
+    text.textContent = data.texto || data.resumo || '';
+    content.appendChild(meta);
+    content.appendChild(text);
+    item.appendChild(avatar);
+    item.appendChild(content);
+    list.appendChild(item);
+  });
+}
+
+function formatDate(str) {
+  if (!str) return '';
+  const [y, m, d] = str.split('-');
+  return `${d}/${m}/${y}`;
+}
+
+function formatDateTime(ts) {
+  let date;
+  if (ts instanceof Timestamp) date = ts.toDate();
+  else if (ts?.toDate) date = ts.toDate();
+  else date = new Date(ts);
+  const pad = n => n.toString().padStart(2, '0');
+  return `${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${date.getFullYear()} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -184,45 +184,44 @@
       </div>
     </div>
 
-    <div id="task-modal-dash" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
+    <!-- Modal Detalhes da Tarefa -->
+    <div id="task-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
       <div class="bg-white rounded-lg shadow-lg w-11/12 max-w-2xl max-h-[90vh] overflow-y-auto">
         <div class="flex justify-between items-center p-4 border-b">
           <h3 class="text-lg font-semibold">Detalhes da Tarefa</h3>
-          <button id="btn-fechar-dash" class="text-gray-500 hover:text-gray-700"><i class="fas fa-times"></i></button>
+          <div class="flex items-center gap-2">
+            <button id="btn-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
+            <button id="btn-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+          </div>
         </div>
-        <form id="task-form-dash" class="p-4 space-y-4">
+        <form id="task-form" class="p-4 space-y-4 modal-read">
           <div>
             <label class="block text-sm font-medium">Título</label>
-            <input id="task-titulo-dash" class="w-full border rounded p-2" />
+            <input id="task-titulo" class="w-full border rounded p-2" disabled />
           </div>
           <div>
             <label class="block text-sm font-medium">Talhão</label>
-            <input id="task-talhao-dash" class="w-full border rounded p-2" />
+            <input id="task-talhao" class="w-full border rounded p-2" disabled />
           </div>
           <div>
             <label class="block text-sm font-medium">Vencimento</label>
-            <input id="task-vencimento-dash" type="date" class="w-full border rounded p-2" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Responsável</label>
-            <input id="task-resp-dash" class="w-full border rounded p-2" />
+            <input id="task-vencimento" type="date" class="w-full border rounded p-2" disabled />
           </div>
           <div>
             <label class="block text-sm font-medium">Descrição</label>
-            <textarea id="task-desc-dash" class="w-full border rounded p-2" rows="3"></textarea>
+            <textarea id="task-desc" class="w-full border rounded p-2" rows="3" disabled></textarea>
           </div>
           <div class="flex justify-end gap-2 pt-2">
-            <button type="button" id="btn-salvar-dash" class="bg-green-600 text-white px-4 py-2 rounded">Salvar</button>
-            <button type="button" id="btn-concluir-dash" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
+            <button type="button" id="btn-save" class="hidden bg-green-600 text-white px-4 py-2 rounded">Salvar</button>
+            <button type="button" id="btn-complete" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
           </div>
         </form>
         <div class="p-4 border-t space-y-4">
-          <h4 class="text-md font-semibold">Comentários</h4>
-          <div id="commentsListDash" class="space-y-2"></div>
-          <div class="flex items-start gap-2">
-            <textarea id="comment-input-dash" class="flex-1 border rounded p-2" rows="2" placeholder="Escreva um comentário"></textarea>
-            <button id="btn-add-comment-dash" class="bg-gray-700 text-white px-3 py-2 rounded">Adicionar comentário</button>
+          <div class="flex items-center gap-2">
+            <input id="comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
+            <button id="btn-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
           </div>
+          <div id="comments-list" class="space-y-3"></div>
         </div>
       </div>
     </div>

--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -60,13 +60,44 @@
   </main>
 
   <!-- Modal Detalhes da Tarefa -->
-  <div id="taskModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
-    <div class="bg-white rounded-lg shadow-lg w-11/12 max-w-md">
+  <div id="task-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
+    <div class="bg-white rounded-lg shadow-lg w-11/12 max-w-2xl max-h-[90vh] overflow-y-auto">
       <div class="flex justify-between items-center p-4 border-b">
         <h3 class="text-lg font-semibold">Detalhes da Tarefa</h3>
-        <button id="closeTaskModal" class="text-gray-500 hover:text-gray-700"><i class="fas fa-times"></i></button>
+        <div class="flex items-center gap-2">
+          <button id="btn-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
+          <button id="btn-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+        </div>
       </div>
-      <div id="taskModalContent" class="p-4 space-y-2"></div>
+      <form id="task-form" class="p-4 space-y-4 modal-read">
+        <div>
+          <label class="block text-sm font-medium">Título</label>
+          <input id="task-titulo" class="w-full border rounded p-2" disabled />
+        </div>
+        <div>
+          <label class="block text-sm font-medium">Talhão</label>
+          <input id="task-talhao" class="w-full border rounded p-2" disabled />
+        </div>
+        <div>
+          <label class="block text-sm font-medium">Vencimento</label>
+          <input id="task-vencimento" type="date" class="w-full border rounded p-2" disabled />
+        </div>
+        <div>
+          <label class="block text-sm font-medium">Descrição</label>
+          <textarea id="task-desc" class="w-full border rounded p-2" rows="3" disabled></textarea>
+        </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" id="btn-save" class="hidden bg-green-600 text-white px-4 py-2 rounded">Salvar</button>
+          <button type="button" id="btn-complete" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
+        </div>
+      </form>
+      <div class="p-4 border-t space-y-4">
+        <div class="flex items-center gap-2">
+          <input id="comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
+          <button id="btn-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
+        </div>
+        <div id="comments-list" class="space-y-3"></div>
+      </div>
     </div>
   </div>
 

--- a/public/style.css
+++ b/public/style.css
@@ -692,3 +692,53 @@ button:active, .btn:active {
 #chart-7dias {
     cursor: pointer;
 }
+
+/* ----- Task modal ----- */
+#task-form.modal-read input[disabled],
+#task-form.modal-read textarea[disabled] {
+    border: none;
+    background: transparent;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.comment-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.comment-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 9999px;
+    background-color: #6B7280;
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+}
+
+.comment-content {
+    flex: 1;
+}
+
+.comment-meta {
+    font-size: 0.75rem;
+    color: #6B7280;
+}
+
+.btn-ghost {
+    background: transparent;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+}
+
+.btn-ghost:hover {
+    background-color: #f3f4f6;
+}


### PR DESCRIPTION
## Summary
- unify task detail modal across operator dashboard and task list
- support editing, completion and comments via shared task-modal module
- add styling utilities for modal read/edit states and comments list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b865acb7c832e8472868addbb2040