### PR TITLE
feat: support initial filters on operator tasks

### DIFF
--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -41,6 +41,7 @@
     <section class="flex-1 overflow-y-auto p-4">
       <div class="bg-white rounded-lg shadow-lg p-4">
         <h2 class="text-lg font-bold mb-4">Minhas Tarefas</h2>
+        <div id="activeFilters" class="mb-4 hidden"></div>
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">


### PR DESCRIPTION
## Summary
- read `dia` and `status` from URL and filter tasks in memory
- show active filter chip with day/status and allow clearing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c69c5f1d8832e812169d428adf492