### PR TITLE
feat: responsive sidebar with counters

### DIFF
--- a/public/js/ui/sidebar.js
+++ b/public/js/ui/sidebar.js
@@ -1,5 +1,5 @@
 // public/js/ui/sidebar.js
-// Sidebar: toggle, active state and Firestore counters
+// Sidebar: off-canvas mobile + counters realtime
 import { db } from '../config/firebase.js';
 import {
   collection,
@@ -9,72 +9,100 @@ import {
   Timestamp
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 
-const API_BASE = window.location.hostname === 'localhost'
-  ? ''
-  : 'https://us-central1-app-organia.cloudfunctions.net';
-
-document.addEventListener('DOMContentLoaded', () => {
+export function initSidebar() {
   const sidebar = document.getElementById('sidebar');
-  const toggle = document.getElementById('sidebarToggle');
-  const backdrop = document.getElementById('sidebarBackdrop');
+  const toggle = document.getElementById('btn-sidebar-toggle');
+  const backdrop = document.getElementById('sidebar-backdrop');
+
+  if (!sidebar || !toggle || !backdrop) return;
+
+  const body = document.body;
+  let focusable = [];
+  let firstFocusable;
+  let lastFocusable;
+
+  const setFocusables = () => {
+    focusable = sidebar.querySelectorAll(
+      'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    firstFocusable = focusable[0];
+    lastFocusable = focusable[focusable.length - 1];
+  };
+
+  const handleKeydown = (e) => {
+    if (e.key === 'Escape') {
+      close();
+    } else if (e.key === 'Tab') {
+      if (focusable.length === 0) return;
+      if (e.shiftKey && document.activeElement === firstFocusable) {
+        e.preventDefault();
+        lastFocusable.focus();
+      } else if (!e.shiftKey && document.activeElement === lastFocusable) {
+        e.preventDefault();
+        firstFocusable.focus();
+      }
+    }
+  };
 
   const open = () => {
-    sidebar?.classList.add('open');
-    backdrop?.classList.add('show');
-    toggle?.setAttribute('aria-expanded', 'true');
+    body.classList.add('sidebar-open');
+    toggle.setAttribute('aria-expanded', 'true');
+    backdrop.setAttribute('aria-hidden', 'false');
+    setFocusables();
+    firstFocusable && firstFocusable.focus();
+    document.addEventListener('keydown', handleKeydown);
   };
 
   const close = () => {
-    sidebar?.classList.remove('open');
-    backdrop?.classList.remove('show');
-    toggle?.setAttribute('aria-expanded', 'false');
+    body.classList.remove('sidebar-open');
+    toggle.setAttribute('aria-expanded', 'false');
+    backdrop.setAttribute('aria-hidden', 'true');
+    document.removeEventListener('keydown', handleKeydown);
+    toggle.focus();
   };
 
-  toggle?.addEventListener('click', () => {
-    sidebar?.classList.contains('open') ? close() : open();
+  toggle.addEventListener('click', () => {
+    body.classList.contains('sidebar-open') ? close() : open();
   });
 
-  backdrop?.addEventListener('click', close);
+  backdrop.addEventListener('click', close);
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth >= 1024) {
+      close();
+    }
+  });
 
   // Active link
   const current = window.location.pathname.split('/').pop();
-  document.querySelectorAll('#sidebar a').forEach(link => {
+  sidebar.querySelectorAll('a.sidebar-link').forEach((link) => {
     if (link.getAttribute('href') === current) {
       link.classList.add('is-active');
       link.setAttribute('aria-current', 'page');
     }
   });
 
-  // Badges: tarefas pending+running
-  const tasksBadge = document.getElementById('tasksBadge');
+  // Sidebar: counters realtime
+  const tasksBadge = document.querySelector('[data-badge="tarefas"]');
   if (tasksBadge) {
-    const q = query(collection(db, 'tarefas'), where('status', 'in', ['pending', 'running']));
-    onSnapshot(q, snap => {
+    const statuses = ['Pendente', 'pendente', 'PENDENTE', 'Atrasada', 'atrasada', 'ATRASADA'];
+    const q = query(collection(db, 'tarefas'), where('status', 'in', statuses));
+    onSnapshot(q, (snap) => {
       const count = snap.size;
       tasksBadge.textContent = count;
       tasksBadge.classList.toggle('show', count > 0);
     });
   }
 
-  // Lista de tarefas na sidebar
-  const sidebarTasks = document.getElementById('sidebarTasks');
-  if (sidebarTasks) {
-    const q = query(
-      collection(db, 'tarefas'),
-      where('status', 'in', ['pending', 'running'])
-    );
-
-    onSnapshot(
-      q,
-      snap => {
-        const tasks = snap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-        sidebarTasks.innerHTML = tasks
-          .map(t => `<a href="operador-tarefas.html#${t.id}" class="sidebar-sublink">${t.talhao || t.tipo || t.id}</a>`)
-          .join('');
-        sidebarTasks.classList.toggle('show', tasks.length > 0);
-      },
-      () => sidebarTasks.classList.remove('show')
-    );
+  const ordersBadge = document.querySelector('[data-badge="ordens"]');
+  if (ordersBadge) {
+    const statuses = ['Aberta', 'aberta', 'ABERTA'];
+    const q = query(collection(db, 'ordens'), where('status', 'in', statuses));
+    onSnapshot(q, (snap) => {
+      const count = snap.size;
+      ordersBadge.textContent = count;
+      ordersBadge.classList.toggle('show', count > 0);
+    });
   }
 
   // Agenda indicator
@@ -96,24 +124,32 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const tarefasCol = collection(db, 'tarefas');
-    onSnapshot(query(tarefasCol, where('vencimento', '>=', start), where('vencimento', '<=', end)), snap => {
-      tasksToday = snap.size > 0;
-      updateIndicator();
-    });
-    onSnapshot(query(tarefasCol, where('vencimento', '==', todayStr)), snap => {
+    onSnapshot(
+      query(tarefasCol, where('vencimento', '>=', start), where('vencimento', '<=', end)),
+      (snap) => {
+        tasksToday = snap.size > 0;
+        updateIndicator();
+      }
+    );
+    onSnapshot(query(tarefasCol, where('vencimento', '==', todayStr)), (snap) => {
       tasksToday = tasksToday || snap.size > 0;
       updateIndicator();
     });
 
     const ordensCol = collection(db, 'ordens');
-    onSnapshot(query(ordensCol, where('prazo', '>=', start), where('prazo', '<=', end)), snap => {
-      ordersToday = snap.size > 0;
-      updateIndicator();
-    });
-    onSnapshot(query(ordensCol, where('prazo', '==', todayStr)), snap => {
+    onSnapshot(
+      query(ordensCol, where('prazo', '>=', start), where('prazo', '<=', end)),
+      (snap) => {
+        ordersToday = snap.size > 0;
+        updateIndicator();
+      }
+    );
+    onSnapshot(query(ordensCol, where('prazo', '==', todayStr)), (snap) => {
       ordersToday = ordersToday || snap.size > 0;
       updateIndicator();
     });
   }
-});
+}
+
+document.addEventListener('DOMContentLoaded', initSidebar);
 

--- a/public/operador-agenda.html
+++ b/public/operador-agenda.html
@@ -12,10 +12,10 @@
 <body class="min-h-screen bg-gray-100">
   <div id="operador-agenda-marker" class="hidden"></div>
 
-  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+  <div id="sidebar-backdrop" class="sidebar-backdrop" aria-hidden="true"></div>
 
   <aside id="sidebar" class="sidebar">
     <div class="sidebar-logo">
@@ -24,18 +24,17 @@
     <!-- Links podem receber data-role para controle de acesso -->
     <nav class="sidebar-nav">
       <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
-      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" data-badge="tarefas" class="sidebar-badge"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-box"></i><span>Ordens</span><span id="ordersBadge" data-badge="ordens" class="sidebar-badge"></span></a>
       <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
       <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
   </aside>
 
   <main class="main-content flex flex-col overflow-hidden">
-    <header class="bg-white border-b">
-      <div class="flex items-center justify-between px-4 py-2">
-        <h1 class="text-lg font-bold text-green-700">Agenda</h1>
-        <button onclick="logout()" class="text-red-600 font-semibold">Sair</button>
-      </div>
+    <header class="dashboard-header">
+      <h1 class="text-lg font-bold text-green-700">Agenda</h1>
+      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
     </header>
 
     <section class="flex-1 overflow-y-auto p-4">

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -18,10 +18,10 @@
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="operador-dashboard-marker" class="hidden"></div>
 
-  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+  <div id="sidebar-backdrop" class="sidebar-backdrop" aria-hidden="true"></div>
 
   <aside id="sidebar" class="sidebar">
     <div class="sidebar-logo">
@@ -30,8 +30,9 @@
     <!-- Links podem receber data-role para controle de acesso -->
     <nav class="sidebar-nav">
       <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
-      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" data-badge="tarefas" class="sidebar-badge"></span></a>
       <div id="sidebarTasks" class="sidebar-submenu"></div>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-box"></i><span>Ordens</span><span id="ordersBadge" data-badge="ordens" class="sidebar-badge"></span></a>
       <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
       <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
@@ -39,10 +40,8 @@
 
     <main class="main-content">
       <header class="dashboard-header">
-        <div class="dashboard-container flex items-center justify-center h-full">
-          <h1 class="text-lg font-semibold text-center">Dashboard do Operador</h1>
-        </div>
-        <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm absolute right-6 top-1/2 -translate-y-1/2"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
+        <h1 class="text-lg font-semibold">Dashboard do Operador</h1>
+        <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
       </header>
 
     <!-- CONTEÚDO PRINCIPAL -->

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Perfil do Operador</title>
+  <title>Ordens do Operador</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer></script>
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="min-h-screen bg-gray-100">
-  <div id="operador-perfil-marker" class="hidden"></div>
+  <div id="operador-ordens-marker" class="hidden"></div>
 
   <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
     <i class="fas fa-bars"></i>
@@ -21,7 +21,6 @@
     <div class="sidebar-logo">
       <img src="logo.png" alt="Orgânia" />
     </div>
-    <!-- Links podem receber data-role para controle de acesso -->
     <nav class="sidebar-nav">
       <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
       <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" data-badge="tarefas" class="sidebar-badge"></span></a>
@@ -33,16 +32,14 @@
 
   <main class="main-content flex flex-col overflow-hidden">
     <header class="dashboard-header">
-      <h1 class="text-lg font-bold text-green-700">Perfil</h1>
+      <h1 class="text-lg font-bold text-green-700">Ordens</h1>
       <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
     </header>
 
     <section class="flex-1 overflow-y-auto p-4">
-      <div class="bg-white rounded-lg shadow-lg p-4 max-w-md">
-        <h2 class="text-lg font-bold mb-4">Informações do Usuário</h2>
-        <p><span class="font-semibold">Nome:</span> <span id="profileName"></span></p>
-        <p><span class="font-semibold">Email:</span> <span id="profileEmail"></span></p>
-        <p><span class="font-semibold">Papel:</span> <span id="profileRole"></span></p>
+      <div class="bg-white rounded-lg shadow-lg p-4">
+        <h2 class="text-lg font-bold mb-4">Minhas Ordens</h2>
+        <p class="text-sm text-gray-600">Em breve...</p>
       </div>
     </section>
   </main>
@@ -51,3 +48,4 @@
   <script type="module" src="js/services/auth.js"></script>
 </body>
 </html>
+

--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -12,10 +12,10 @@
 <body class="min-h-screen bg-gray-100">
   <div id="operador-tarefas-marker" class="hidden"></div>
 
-  <button id="sidebarToggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+  <div id="sidebar-backdrop" class="sidebar-backdrop" aria-hidden="true"></div>
 
   <aside id="sidebar" class="sidebar">
     <div class="sidebar-logo">
@@ -24,18 +24,17 @@
     <!-- Links podem receber data-role para controle de acesso -->
     <nav class="sidebar-nav">
       <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
-      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" class="sidebar-badge"></span></a>
+      <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" data-badge="tarefas" class="sidebar-badge"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-box"></i><span>Ordens</span><span id="ordersBadge" data-badge="ordens" class="sidebar-badge"></span></a>
       <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
       <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
   </aside>
 
   <main class="main-content flex flex-col overflow-hidden">
-    <header class="bg-white border-b">
-      <div class="flex items-center justify-between px-4 py-2">
-        <h1 class="text-lg font-bold text-green-700">Tarefas</h1>
-        <button onclick="logout()" class="text-red-600 font-semibold">Sair</button>
-      </div>
+    <header class="dashboard-header">
+      <h1 class="text-lg font-bold text-green-700">Tarefas</h1>
+      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
     </header>
 
     <section class="flex-1 overflow-y-auto p-4">

--- a/public/style.css
+++ b/public/style.css
@@ -350,9 +350,11 @@ button:active, .btn:active {
     height: 64px;
     display: flex;
     align-items: center;
+    justify-content: center;
     position: relative;
 }
 
+/* Header: Sair à direita */
 .dashboard-btn {
     background: transparent;
     border: 1px solid #E5E7EB;
@@ -362,6 +364,10 @@ button:active, .btn:active {
     border-radius: 8px;
     font-weight: 600;
     transition: background-color 0.2s;
+    position: absolute;
+    right: 24px;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .dashboard-btn:hover {
@@ -450,7 +456,8 @@ button:active, .btn:active {
 }
 
 /* Sidebar: layout and utility classes */
-.sidebar {
+/* Sidebar: off-canvas mobile */
+#sidebar {
     position: fixed;
     top: 0;
     left: 0;
@@ -463,7 +470,7 @@ button:active, .btn:active {
     z-index: 50;
 }
 
-.sidebar.open {
+body.sidebar-open #sidebar {
     transform: translateX(0);
 }
 
@@ -574,16 +581,19 @@ button:active, .btn:active {
     display: block;
 }
 
-.sidebar-backdrop {
+#sidebar-backdrop {
     position: fixed;
     inset: 0;
-    background: rgba(0,0,0,0.4);
+    background: rgba(0,0,0,0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
     z-index: 40;
-    display: none;
 }
 
-.sidebar-backdrop.show {
-    display: block;
+body.sidebar-open #sidebar-backdrop {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 .sidebar-toggle {
@@ -602,14 +612,18 @@ button:active, .btn:active {
     padding: 0;
 }
 
+body.sidebar-open {
+    overflow: hidden;
+}
+
 @media (min-width: 1024px) {
-    .sidebar {
+    #sidebar {
         transform: none;
     }
-    .sidebar-toggle {
+    #btn-sidebar-toggle {
         display: none;
     }
-    .sidebar-backdrop {
+    #sidebar-backdrop {
         display: none !important;
     }
     .main-content {


### PR DESCRIPTION
## Summary
- make sidebar mobile friendly with off-canvas layout and aria enhancements
- show real-time Firestore counters for tasks and orders
- align logout button to right in page headers

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c77248c9c832e911228d673d21751