### PR TITLE
feat: add operator orders page

### DIFF
--- a/public/js/pages/operador-ordens.js
+++ b/public/js/pages/operador-ordens.js
@@ -1,0 +1,252 @@
+/* Ordens: filtros + tabela harmonizada */
+
+const state = {
+  orders: [
+    {
+      id: 'ORD-001',
+      cliente: 'Fazenda Modelo',
+      propriedade: 'Sítio 1',
+      talhao: 'A1',
+      abertura: '2024-06-01',
+      prazo: '2024-06-10',
+      status: 'Aberta',
+      total: 1500,
+      itens: 'Item 1 - 10kg',
+      obs: '',
+      comments: []
+    },
+    {
+      id: 'ORD-002',
+      cliente: 'Fazenda Beta',
+      propriedade: 'Área Central',
+      talhao: 'B2',
+      abertura: '2024-06-03',
+      prazo: '2024-06-15',
+      status: 'Em andamento',
+      total: 820,
+      itens: 'Item 2 - 5un',
+      obs: '',
+      comments: []
+    }
+  ],
+  current: null,
+  editing: false
+};
+
+const ordersTable = document.getElementById('orders-table');
+const modal = document.getElementById('order-modal');
+const form = document.getElementById('order-form');
+const commentList = document.getElementById('order-comments-list');
+
+render();
+document.getElementById('filter-status').addEventListener('change', render);
+document.getElementById('filter-search').addEventListener('input', render);
+
+document.getElementById('btn-order-close').addEventListener('click', closeModal);
+document.getElementById('btn-order-edit').addEventListener('click', enableEdit);
+document.getElementById('btn-order-save').addEventListener('click', saveEdit);
+document.getElementById('btn-order-conclude').addEventListener('click', () => updateStatus('Concluída'));
+document.getElementById('btn-order-cancel').addEventListener('click', () => updateStatus('Cancelada'));
+document.getElementById('btn-order-add-comment').addEventListener('click', addComment);
+
+function render() {
+  if (!ordersTable) return;
+  ordersTable.innerHTML = '';
+  const statusFilter = document.getElementById('filter-status').value;
+  const search = document.getElementById('filter-search').value.toLowerCase();
+
+  getFilteredOrders(statusFilter, search).forEach(o => {
+    const tr = document.createElement('tr');
+    tr.className = 'border-b border-gray-200 hover:bg-gray-100';
+
+    tr.innerHTML = `
+      <td class="px-3 py-3">${o.id}</td>
+      <td class="px-3 py-3 max-w-[200px] truncate">${o.cliente}</td>
+      <td class="px-3 py-3">${o.talhao}</td>
+      <td class="px-3 py-3 min-w-[112px]">${o.prazo}</td>
+      <td class="px-3 py-3 min-w-[120px]">${renderStatus(o.status)}</td>
+      <td class="px-3 py-3 min-w-[96px] text-right">${o.total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</td>
+      <td class="px-3 py-3">
+        <div class="flex gap-2">
+          <button class="btn-ghost text-gray-600" title="Ver detalhes" data-action="view" data-id="${o.id}"><i class="fas fa-eye"></i></button>
+          <button class="btn-ghost text-gray-600" title="Encerrar" data-action="done" data-id="${o.id}"><i class="fas fa-flag-checkered"></i></button>
+          <button class="btn-ghost text-gray-600" title="Cancelar" data-action="cancel" data-id="${o.id}"><i class="fas fa-ban"></i></button>
+        </div>
+      </td>`;
+
+    ordersTable.appendChild(tr);
+  });
+
+  ordersTable.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', handleRowAction);
+  });
+}
+
+function getFilteredOrders(status, term) {
+  return state.orders.filter(o => {
+    const matchesStatus = status === 'todas' || normalize(o.status) === status;
+    const matchesTerm = !term ||
+      o.id.toLowerCase().includes(term) ||
+      (o.cliente + o.propriedade).toLowerCase().includes(term);
+    return matchesStatus && matchesTerm;
+  });
+}
+
+function handleRowAction(e) {
+  const id = e.currentTarget.dataset.id;
+  const action = e.currentTarget.dataset.action;
+  const order = state.orders.find(o => o.id === id);
+  if (!order) return;
+  if (action === 'view') {
+    openModal(order);
+  } else if (action === 'done') {
+    state.current = order;
+    updateStatus('Concluída');
+  } else if (action === 'cancel') {
+    state.current = order;
+    updateStatus('Cancelada');
+  }
+}
+
+function renderStatus(status) {
+  const cls = {
+    'aberta': 'aberta',
+    'em andamento': 'em-andamento',
+    'concluída': 'concluida',
+    'cancelada': 'cancelada'
+  }[normalize(status)] || 'default';
+  return `<span class="status-pill ${cls}">${status}</span>`;
+}
+
+function openModal(order) {
+  state.current = order;
+  form.classList.add('modal-read');
+  state.editing = false;
+  fillForm(order);
+  renderComments();
+  modal.classList.remove('hidden');
+  document.getElementById('order-codigo').focus();
+}
+
+function closeModal() {
+  modal.classList.add('hidden');
+}
+
+function enableEdit() {
+  if (!state.current) return;
+  state.editing = true;
+  form.classList.remove('modal-read');
+  toggleFormFields(false);
+  document.getElementById('btn-order-save').classList.remove('hidden');
+}
+
+function saveEdit() {
+  if (!state.current) return;
+  const o = state.current;
+  const diffs = [];
+  const map = {
+    'order-cliente': 'cliente',
+    'order-propriedade': 'propriedade',
+    'order-talhao': 'talhao',
+    'order-prazo': 'prazo',
+    'order-itens': 'itens',
+    'order-obs': 'obs'
+  };
+  for (const id in map) {
+    const field = map[id];
+    const el = document.getElementById(id);
+    if (el && o[field] !== el.value) {
+      diffs.push(`${field}: ${o[field] || ''} → ${el.value}`);
+      o[field] = el.value;
+    }
+  }
+  if (diffs.length) {
+    o.comments.unshift({
+      author: 'Usuário',
+      text: '✏️ ' + diffs.join(', '),
+      date: new Date()
+    });
+    renderComments();
+    render();
+  }
+  state.editing = false;
+  form.classList.add('modal-read');
+  toggleFormFields(true);
+  document.getElementById('btn-order-save').classList.add('hidden');
+}
+
+function updateStatus(newStatus) {
+  if (!state.current) return;
+  state.current.status = newStatus;
+  state.current.comments.unshift({
+    author: 'Usuário',
+    text: `${newStatus === 'Concluída' ? '✅ Concluída' : '⛔ Cancelada'} por Usuário`,
+    date: new Date()
+  });
+  renderComments();
+  render();
+}
+
+function addComment() {
+  if (!state.current) return;
+  const input = document.getElementById('order-comment-input');
+  const txt = input.value.trim();
+  if (!txt) return;
+  state.current.comments.unshift({ author: 'Usuário', text: txt, date: new Date() });
+  input.value = '';
+  renderComments();
+}
+
+function renderComments() {
+  if (!state.current) return;
+  commentList.innerHTML = '';
+  state.current.comments.forEach(c => {
+    const item = document.createElement('div');
+    item.className = 'comment-item';
+    item.innerHTML = `
+      <div class="comment-avatar">${c.author.charAt(0).toUpperCase()}</div>
+      <div class="comment-content">
+        <p class="text-sm">${c.text}</p>
+        <span class="comment-meta">${c.author} • ${formatDate(c.date)}</span>
+      </div>`;
+    commentList.appendChild(item);
+  });
+}
+
+function fillForm(o) {
+  document.getElementById('order-codigo').value = o.id || '';
+  document.getElementById('order-cliente').value = o.cliente || '';
+  document.getElementById('order-propriedade').value = o.propriedade || '';
+  document.getElementById('order-talhao').value = o.talhao || '';
+  document.getElementById('order-abertura').value = o.abertura || '';
+  document.getElementById('order-prazo').value = o.prazo || '';
+  document.getElementById('order-itens').value = o.itens || '';
+  document.getElementById('order-obs').value = o.obs || '';
+  toggleFormFields(true);
+  document.getElementById('btn-order-save').classList.add('hidden');
+}
+
+function toggleFormFields(disabled) {
+  ['order-cliente','order-propriedade','order-talhao','order-prazo','order-itens','order-obs'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.disabled = disabled;
+  });
+}
+
+function normalize(str) {
+  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+}
+
+function formatDate(d) {
+  return new Date(d).toLocaleDateString('pt-BR', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit'
+  });
+}
+
+function closeOnEsc(e) {
+  if (e.key === 'Escape' && !modal.classList.contains('hidden')) closeModal();
+}
+
+window.addEventListener('keydown', closeOnEsc);
+

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -9,7 +9,7 @@
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="min-h-screen bg-gray-100">
+<body class="min-h-screen bg-[#F9FAFB]">
   <div id="operador-ordens-marker" class="hidden"></div>
 
   <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
@@ -24,8 +24,8 @@
     <nav class="sidebar-nav">
       <a href="operador-dashboard.html" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a>
       <a href="operador-tarefas.html" class="sidebar-link"><i class="fas fa-tasks"></i><span>Tarefas</span><span id="tasksBadge" data-badge="tarefas" class="sidebar-badge"></span></a>
-      <a href="operador-ordens.html" class="sidebar-link"><i class="fas fa-box"></i><span>Ordens</span><span id="ordersBadge" data-badge="ordens" class="sidebar-badge"></span></a>
-      <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicator" class="sidebar-indicator"></span></a>
+      <a href="operador-ordens.html" class="sidebar-link" aria-current="page"><i class="fas fa-box"></i><span>Ordens</span><span id="ordersBadge" data-badge="ordens" class="sidebar-badge"></span></a>
+      <a href="operador-agenda.html" class="sidebar-link"><i class="fas fa-calendar"></i><span>Agenda</span><span id="agendaIndicador" class="sidebar-indicator"></span></a>
       <a href="operador-perfil.html" class="sidebar-link"><i class="fas fa-user"></i><span>Perfil</span></a>
     </nav>
   </aside>
@@ -36,15 +36,130 @@
       <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
     </header>
 
-    <section class="flex-1 overflow-y-auto p-4">
-      <div class="bg-white rounded-lg shadow-lg p-4">
-        <h2 class="text-lg font-bold mb-4">Minhas Ordens</h2>
-        <p class="text-sm text-gray-600">Em breve...</p>
+    <section class="flex-1 overflow-y-auto py-6">
+      <div class="max-w-[1240px] mx-auto px-4 md:px-6">
+        <div class="bg-white rounded-xl shadow-md border border-gray-200 p-5">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between mb-4">
+            <h2 class="text-lg font-bold">Minhas Ordens</h2>
+            <div class="flex flex-col gap-3 w-full lg:flex-row lg:w-auto lg:items-center">
+              <div class="flex flex-col sm:flex-row sm:flex-wrap gap-3 flex-1">
+                <div>
+                  <label for="filter-status" class="block text-xs font-medium text-gray-500">Status</label>
+                  <select id="filter-status" class="mt-1 w-full border rounded-md h-11 px-3">
+                    <option value="todas">Todas</option>
+                    <option value="aberta">Aberta</option>
+                    <option value="em andamento">Em andamento</option>
+                    <option value="concluida">Concluída</option>
+                    <option value="cancelada">Cancelada</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="filter-client" class="block text-xs font-medium text-gray-500">Cliente/Propriedade</label>
+                  <select id="filter-client" class="mt-1 w-full border rounded-md h-11 px-3">
+                    <option value="">Todos</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="filter-period" class="block text-xs font-medium text-gray-500">Período</label>
+                  <select id="filter-period" class="mt-1 w-full border rounded-md h-11 px-3">
+                    <option>Últimos 7 dias</option>
+                    <option>Últimos 30 dias</option>
+                    <option>Este mês</option>
+                    <option>Personalizado</option>
+                  </select>
+                </div>
+                <div class="flex-1">
+                  <label for="filter-search" class="block text-xs font-medium text-gray-500">Busca</label>
+                  <input id="filter-search" type="text" class="mt-1 w-full border rounded-md h-11 px-3" placeholder="Código, cliente..." />
+                </div>
+              </div>
+              <button id="btn-new-order" class="h-11 px-4 bg-[#6C9F3D] hover:bg-[#5A8733] text-white rounded-md flex items-center justify-center gap-2 self-end lg:self-auto"><i class="fas fa-plus"></i><span>Nova Ordem</span></button>
+            </div>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full table-auto">
+              <thead class="bg-gray-50">
+                <tr class="text-left text-[13px] font-semibold text-gray-700 h-10">
+                  <th scope="col" class="px-3">Código</th>
+                  <th scope="col" class="px-3">Cliente/Propriedade</th>
+                  <th scope="col" class="px-3">Talhão</th>
+                  <th scope="col" class="px-3 min-w-[112px]">Prazo</th>
+                  <th scope="col" class="px-3 min-w-[120px]">Status</th>
+                  <th scope="col" class="px-3 min-w-[96px] text-right">Total (R$)</th>
+                  <th scope="col" class="px-3">Ações</th>
+                </tr>
+              </thead>
+              <tbody id="orders-table" class="text-sm"></tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </section>
   </main>
 
+  <!-- Modal ordem com comentários -->
+  <div id="order-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
+    <div class="bg-white rounded-xl shadow-lg w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto p-6">
+      <div class="flex justify-between items-center mb-4">
+        <h3 class="text-lg font-semibold">Detalhes da Ordem</h3>
+        <div class="flex items-center gap-2">
+          <button id="btn-order-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
+          <button id="btn-order-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+        </div>
+      </div>
+      <form id="order-form" class="space-y-4 modal-read">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label for="order-codigo" class="block text-sm text-gray-600">Código</label>
+            <input id="order-codigo" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-cliente" class="block text-sm text-gray-600">Cliente</label>
+            <input id="order-cliente" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-propriedade" class="block text-sm text-gray-600">Propriedade</label>
+            <input id="order-propriedade" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-talhao" class="block text-sm text-gray-600">Talhão</label>
+            <input id="order-talhao" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-abertura" class="block text-sm text-gray-600">Abertura</label>
+            <input id="order-abertura" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-prazo" class="block text-sm text-gray-600">Prazo</label>
+            <input id="order-prazo" type="date" class="w-full border rounded p-2" disabled />
+          </div>
+        </div>
+        <div>
+          <label for="order-itens" class="block text-sm text-gray-600">Itens</label>
+          <textarea id="order-itens" class="w-full border rounded p-2" rows="3" disabled></textarea>
+        </div>
+        <div>
+          <label for="order-obs" class="block text-sm text-gray-600">Observações</label>
+          <textarea id="order-obs" class="w-full border rounded p-2" rows="3" disabled></textarea>
+        </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" id="btn-order-save" class="hidden bg-[#6C9F3D] hover:bg-[#5A8733] text-white px-4 py-2 rounded">Salvar</button>
+          <button type="button" id="btn-order-conclude" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
+          <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
+        </div>
+      </form>
+      <div class="mt-4 space-y-4 border-t pt-4">
+        <div class="flex items-center gap-2">
+          <input id="order-comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
+          <button id="btn-order-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
+        </div>
+        <div id="order-comments-list" class="space-y-3"></div>
+      </div>
+    </div>
+  </div>
+
   <script type="module" src="js/ui/sidebar.js"></script>
+  <script type="module" src="js/pages/operador-ordens.js"></script>
   <script type="module" src="js/services/auth.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -668,6 +668,38 @@ body.sidebar-open {
     border-color: #D1D5DB;
 }
 
+/* Pílulas status ordens */
+.status-pill.aberta,
+.status-pill.em-andamento,
+.status-pill.concluida,
+.status-pill.cancelada {
+    padding: 2px 8px;
+}
+
+.status-pill.aberta {
+    background: #DBEAFE;
+    color: #1E40AF;
+    border-color: #BFDBFE;
+}
+
+.status-pill.em-andamento {
+    background: #FEF9C3;
+    color: #854D0E;
+    border-color: #FEF08A;
+}
+
+.status-pill.concluida {
+    background: #DCFCE7;
+    color: #166534;
+    border-color: #BBF7D0;
+}
+
+.status-pill.cancelada {
+    background: #FEE2E2;
+    color: #991B1B;
+    border-color: #FECACA;
+}
+
 /* Simple skeleton loader */
 .skeleton {
     background: #E5E7EB;


### PR DESCRIPTION
## Summary
- add operator orders page with filter card and orders table
- style order status pills and modal for viewing/editing orders

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c7bef2f24832ebc4136dd80451ba3