### PR TITLE
feat: link tasks with orders and track progress

### DIFF
--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -85,6 +85,7 @@
                   <th scope="col" class="px-3">Talhão</th>
                   <th scope="col" class="px-3 min-w-[112px]">Prazo</th>
                   <th scope="col" class="px-3 min-w-[120px]">Status</th>
+                  <th scope="col" class="px-3 w-32">Tarefas</th>
                   <th scope="col" class="px-3 min-w-[96px] text-right">Total (R$)</th>
                   <th scope="col" class="px-3">Ações</th>
                 </tr>
@@ -142,12 +143,33 @@
           <label for="order-obs" class="block text-sm text-gray-600">Observações</label>
           <textarea id="order-obs" class="w-full border rounded p-2" rows="3" disabled></textarea>
         </div>
-        <div class="flex justify-end gap-2 pt-2">
-          <button type="button" id="btn-order-save" class="hidden bg-[#6C9F3D] hover:bg-[#5A8733] text-white px-4 py-2 rounded">Salvar</button>
-          <button type="button" id="btn-order-conclude" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
-          <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
-        </div>
+      <div class="flex justify-end gap-2 pt-2">
+        <button type="button" id="btn-order-save" class="hidden bg-[#6C9F3D] hover:bg-[#5A8733] text-white px-4 py-2 rounded">Salvar</button>
+        <button type="button" id="btn-order-conclude" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
+        <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
+      </div>
       </form>
+      <div id="order-tasks" class="mt-6">
+        <div class="flex justify-between items-center mb-2">
+          <h4 class="text-sm font-semibold">Tarefas desta ordem</h4>
+          <button id="btn-order-new-task" class="btn-ghost text-sm text-blue-600 flex items-center gap-1"><i class="fas fa-plus"></i><span>Nova Tarefa</span></button>
+        </div>
+        <div class="mb-2">
+          <div class="task-progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div style="width:0%"></div></div>
+          <div id="order-tasks-counter" class="text-xs text-gray-600 mt-1"></div>
+        </div>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="px-2 py-2 text-left">Título</th>
+              <th scope="col" class="px-2 py-2 text-left">Vencimento</th>
+              <th scope="col" class="px-2 py-2 text-left">Status</th>
+              <th scope="col" class="px-2 py-2 text-left">Ações</th>
+            </tr>
+          </thead>
+          <tbody id="order-tasks-list"></tbody>
+        </table>
+      </div>
       <div class="mt-4 space-y-4 border-t pt-4">
         <div class="flex items-center gap-2">
           <input id="order-comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />

--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -49,6 +49,7 @@
                 <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Tipo</th>
                 <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Vencimento</th>
                 <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Status</th>
+                <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Ordem</th>
                 <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Ações</th>
               </tr>
             </thead>
@@ -63,7 +64,10 @@
   <div id="task-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
     <div class="bg-white rounded-lg shadow-lg w-11/12 max-w-2xl max-h-[90vh] overflow-y-auto">
       <div class="flex justify-between items-center p-4 border-b">
-        <h3 class="text-lg font-semibold">Detalhes da Tarefa</h3>
+        <div class="flex items-center gap-2">
+          <h3 class="text-lg font-semibold">Detalhes da Tarefa</h3>
+          <button id="task-order-chip" class="order-chip hidden" title=""></button>
+        </div>
         <div class="flex items-center gap-2">
           <button id="btn-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
           <button id="btn-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
@@ -100,8 +104,89 @@
       </div>
     </div>
   </div>
-
+  <!-- Modal ordem reutilizado -->
+  <div id="order-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
+    <div class="bg-white rounded-xl shadow-lg w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto p-6">
+      <div class="flex justify-between items-center mb-4">
+        <h3 class="text-lg font-semibold">Detalhes da Ordem</h3>
+        <div class="flex items-center gap-2">
+          <button id="btn-order-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
+          <button id="btn-order-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+        </div>
+      </div>
+      <form id="order-form" class="space-y-4 modal-read">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label for="order-codigo" class="block text-sm text-gray-600">Código</label>
+            <input id="order-codigo" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-cliente" class="block text-sm text-gray-600">Cliente</label>
+            <input id="order-cliente" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-propriedade" class="block text-sm text-gray-600">Propriedade</label>
+            <input id="order-propriedade" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-talhao" class="block text-sm text-gray-600">Talhão</label>
+            <input id="order-talhao" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-abertura" class="block text-sm text-gray-600">Abertura</label>
+            <input id="order-abertura" class="w-full border rounded p-2" disabled />
+          </div>
+          <div>
+            <label for="order-prazo" class="block text-sm text-gray-600">Prazo</label>
+            <input id="order-prazo" type="date" class="w-full border rounded p-2" disabled />
+          </div>
+        </div>
+        <div>
+          <label for="order-itens" class="block text-sm text-gray-600">Itens</label>
+          <textarea id="order-itens" class="w-full border rounded p-2" rows="3" disabled></textarea>
+        </div>
+        <div>
+          <label for="order-obs" class="block text-sm text-gray-600">Observações</label>
+          <textarea id="order-obs" class="w-full border rounded p-2" rows="3" disabled></textarea>
+        </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" id="btn-order-save" class="hidden bg-[#6C9F3D] hover:bg-[#5A8733] text-white px-4 py-2 rounded">Salvar</button>
+          <button type="button" id="btn-order-conclude" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
+          <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
+        </div>
+      </form>
+      <div id="order-tasks" class="mt-6">
+        <div class="flex justify-between items-center mb-2">
+          <h4 class="text-sm font-semibold">Tarefas desta ordem</h4>
+          <button id="btn-order-new-task" class="btn-ghost text-sm text-blue-600 flex items-center gap-1"><i class="fas fa-plus"></i><span>Nova Tarefa</span></button>
+        </div>
+        <div class="mb-2">
+          <div class="task-progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div style="width:0%"></div></div>
+          <div id="order-tasks-counter" class="text-xs text-gray-600 mt-1"></div>
+        </div>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="px-2 py-2 text-left">Título</th>
+              <th scope="col" class="px-2 py-2 text-left">Vencimento</th>
+              <th scope="col" class="px-2 py-2 text-left">Status</th>
+              <th scope="col" class="px-2 py-2 text-left">Ações</th>
+            </tr>
+          </thead>
+          <tbody id="order-tasks-list"></tbody>
+        </table>
+      </div>
+      <div class="mt-4 space-y-4 border-t pt-4">
+        <div class="flex items-center gap-2">
+          <input id="order-comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
+          <button id="btn-order-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
+        </div>
+        <div id="order-comments-list" class="space-y-3"></div>
+      </div>
+    </div>
+  </div>
   <script type="module" src="js/ui/sidebar.js"></script>
+  <script type="module" src="js/pages/operador-ordens.js"></script>
   <script type="module" src="js/pages/operador-tarefas.js"></script>
   <script type="module" src="js/services/auth.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -788,3 +788,30 @@ body.sidebar-open {
 .btn-ghost:hover {
     background-color: #f3f4f6;
 }
+
+/* Chip ordem em tarefas */
+.order-chip {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    background-color: #DBEAFE;
+    color: #1E40AF;
+    border: 1px solid #BFDBFE;
+}
+
+/* Progresso de tarefas na tabela de ordens */
+.task-progress {
+    width: 100%;
+    height: 6px;
+    border-radius: 9999px;
+    background-color: #E5E7EB;
+    overflow: hidden;
+}
+
+.task-progress > div {
+    height: 100%;
+    background-color: #86EFAC;
+    border-radius: 9999px;
+}


### PR DESCRIPTION
## Summary
- show related order chips on task list and modal
- display task progress for each order and list order tasks in modal
- style order link chip and progress bar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c81d7d884832eb6b8d259d7f5ed15