### PR TITLE
feat: add reusable order modal and design tokens

### DIFF
--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -1,0 +1,144 @@
+import { db } from '../config/firebase.js';
+import {
+  doc,
+  getDoc,
+  collection,
+  query,
+  where,
+  onSnapshot,
+  Timestamp
+} from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+import { openTaskModal } from './task-modal.js';
+
+let modal;
+let currentOrder = null;
+let unsubscribeTasks = null;
+
+export function initOrderModal() {
+  if (window.__orderModalInited) return;
+  modal = document.getElementById('order-modal');
+  if (!modal) return;
+  window.__orderModalInited = true;
+  document.getElementById('btn-order-close')?.addEventListener('click', closeModal);
+  modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+  document.getElementById('btn-order-new-task')?.addEventListener('click', () => {
+    if (!currentOrder) return;
+    openTaskModal(null, {
+      mode: 'create',
+      ordemId: currentOrder.id,
+      ordemCodigo: currentOrder.codigo,
+      prefill: { vencimento: currentOrder.prazo }
+    });
+  });
+  document.getElementById('order-tasks-list')?.addEventListener('click', e => {
+    const btn = e.target.closest('[data-action="view-task"]');
+    if (!btn) return;
+    closeModal();
+    openTaskModal(btn.dataset.taskId, { mode: 'view' });
+  });
+}
+
+export async function openOrderModal(orderId) {
+  initOrderModal();
+  document.getElementById('task-modal')?.classList.add('hidden');
+  if (!modal) return;
+  if (unsubscribeTasks) { unsubscribeTasks(); unsubscribeTasks = null; }
+  currentOrder = { id: orderId };
+  const orderRef = doc(db, 'orders', orderId);
+  const snap = await getDoc(orderRef);
+  if (snap.exists()) {
+    const data = snap.data();
+    currentOrder.codigo = data.codigo || orderId;
+    currentOrder.prazo = data.prazo || '';
+    document.getElementById('order-codigo').value = currentOrder.codigo;
+    document.getElementById('order-cliente').value = data.cliente || '';
+    document.getElementById('order-propriedade').value = data.propriedade || '';
+    document.getElementById('order-talhao').value = data.talhao || '';
+    document.getElementById('order-abertura').value = data.abertura || '';
+    document.getElementById('order-prazo').value = data.prazo || '';
+    document.getElementById('order-itens').value = data.itens || '';
+    document.getElementById('order-obs').value = data.obs || '';
+  }
+  loadTasks(orderId);
+  modal.classList.remove('hidden');
+}
+
+function loadTasks(orderId) {
+  const list = document.getElementById('order-tasks-list');
+  if (list) list.innerHTML = '';
+  const q = query(collection(db, 'tasks'), where('ordemId', '==', orderId));
+  unsubscribeTasks = onSnapshot(q, snap => {
+    const frag = document.createDocumentFragment();
+    let total = 0, completed = 0, open = 0;
+    snap.forEach(d => {
+      const data = d.data();
+      const status = taskStatus(data);
+      total++;
+      if (status === 'Concluída') completed++;
+      if (status === 'Pendente' || status === 'Atrasada') open++;
+      const dueRaw = data.dueDate || data.vencimento;
+      const dueDate = dueRaw ? parseDateLocal(dueRaw) : null;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${data.title || d.id}</td>
+        <td>${dueDate ? formatDDMMYYYY(dueDate) : '-'}</td>
+        <td>${renderTaskStatus(status)}</td>
+        <td><button type="button" class="btn-ghost text-blue-700" data-action="view-task" data-task-id="${d.id}">Ver detalhes</button></td>`;
+      frag.appendChild(tr);
+    });
+    list?.replaceChildren(frag);
+    const counter = document.getElementById('order-tasks-counter');
+    if (counter) counter.textContent = `${open}/${total} abertas`;
+    const bar = document.querySelector('#order-tasks .progress__bar');
+    const percent = total ? (completed / total) * 100 : 0;
+    if (bar) bar.style.width = `${percent}%`;
+  });
+}
+
+function closeModal() {
+  modal?.classList.add('hidden');
+  if (unsubscribeTasks) { unsubscribeTasks(); unsubscribeTasks = null; }
+}
+
+function taskStatus(t) {
+  if (t.status === 'Concluída') return 'Concluída';
+  const due = t.dueDate || t.vencimento;
+  if (due) {
+    const d = parseDateLocal(due);
+    if (endOfLocalDay(d) < nowLocal()) return 'Atrasada';
+  }
+  return 'Pendente';
+}
+
+function renderTaskStatus(st) {
+  const cls = st === 'Concluída'
+    ? 'pill pill--success'
+    : st === 'Atrasada'
+    ? 'pill pill--danger'
+    : 'pill pill--warn';
+  return `<span class="${cls}">${st}</span>`;
+}
+
+function parseDateLocal(v) {
+  if (!v) return null;
+  if (v instanceof Timestamp) return v.toDate();
+  if (typeof v === 'string') {
+    const [y, m, d] = v.split('-').map(Number);
+    return new Date(y, m - 1, d);
+  }
+  return new Date(v);
+}
+
+function formatDDMMYYYY(d) {
+  return d.toLocaleDateString('pt-BR', { timeZone: 'America/Sao_Paulo' });
+}
+
+function nowLocal() {
+  return new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' }));
+}
+
+function endOfLocalDay(d) {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+}
+
+window.openOrderModal = openOrderModal;

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -99,19 +99,19 @@
   </main>
 
   <!-- Modal tarefa reutilizado -->
-  <div id="task-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
-    <div class="bg-white rounded-lg shadow-lg w-11/12 max-w-2xl max-h-[90vh] overflow-y-auto">
-      <div class="flex justify-between items-center p-4 border-b">
+  <div id="task-modal" class="modal modal--task hidden" aria-modal="true" role="dialog">
+    <div class="modal__content">
+      <header class="modal__header">
         <div class="flex items-center gap-2">
-          <h3 class="text-lg font-semibold">Detalhes da Tarefa</h3>
-          <button id="task-order-chip" class="order-chip hidden" title=""></button>
+          <h3 class="modal__title">Detalhes da Tarefa</h3>
+          <button id="task-order-chip" class="chip hidden" title=""></button>
         </div>
-        <div class="flex items-center gap-2">
-          <button id="btn-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
-          <button id="btn-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+        <div class="modal__actions">
+          <button id="btn-edit" class="btn-ghost text-gray-600" aria-label="Editar"><i class="fas fa-pen"></i></button>
+          <button id="btn-close" class="text-gray-600 hover:text-gray-800" aria-label="Fechar"><i class="fas fa-times"></i></button>
         </div>
-      </div>
-      <form id="task-form" class="p-4 space-y-4 modal-read">
+      </header>
+      <form id="task-form" class="modal__body space-y-4 modal-read">
         <div>
           <label class="block text-sm font-medium">Título</label>
           <input id="task-titulo" class="w-full border rounded p-2" disabled />
@@ -133,7 +133,7 @@
           <button type="button" id="btn-complete" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
         </div>
       </form>
-      <div class="p-4 border-t space-y-4">
+      <div class="modal__body border-t space-y-4">
         <div class="flex items-center gap-2">
           <input id="comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
           <button id="btn-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
@@ -144,17 +144,17 @@
   </div>
 
   <!-- Modal ordem com comentários -->
-  <div id="order-modal" data-mode="view" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
-    <div class="bg-white rounded-xl shadow-lg w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto p-6">
-      <div class="flex justify-between items-center mb-4">
-        <h3 id="order-modal-title" class="text-lg font-semibold">Detalhes da Ordem</h3>
-        <div class="flex items-center gap-2">
+  <div id="order-modal" data-mode="view" class="modal modal--order hidden" aria-modal="true" role="dialog">
+    <div class="modal__content p-6">
+      <header class="modal__header">
+        <h3 id="order-modal-title" class="modal__title">Detalhes da Ordem</h3>
+        <div class="modal__actions">
           <button id="btn-order-duplicate" class="btn-ghost text-gray-600" title="Duplicar"><i class="fas fa-copy"></i></button>
-          <button id="btn-order-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
-          <button id="btn-order-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+          <button id="btn-order-edit" class="btn-ghost text-gray-600" aria-label="Editar"><i class="fas fa-pen"></i></button>
+          <button id="btn-order-close" class="text-gray-600 hover:text-gray-800" aria-label="Fechar"><i class="fas fa-times"></i></button>
         </div>
-      </div>
-      <form id="order-form" class="space-y-4 modal-read">
+      </header>
+      <form id="order-form" class="modal__body space-y-4 modal-read">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label for="order-codigo" class="block text-sm text-gray-600">Código</label>
@@ -205,7 +205,7 @@
           <button id="btn-order-new-task" type="button" aria-label="Criar nova tarefa desta ordem" title="Criar nova tarefa desta ordem" class="btn-ghost text-sm text-blue-600 flex items-center gap-1"><i class="fas fa-plus"></i><span>Nova Tarefa</span></button>
         </div>
         <div class="mb-2">
-          <div class="task-progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div style="width:0%"></div></div>
+          <div class="progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div class="progress__bar" style="width:0%"></div></div>
           <div id="order-tasks-counter" class="text-xs text-gray-600 mt-1" aria-live="polite"></div>
         </div>
         <table class="w-full text-sm">
@@ -220,7 +220,7 @@
           <tbody id="order-tasks-list"></tbody>
         </table>
       </div>
-      <div class="mt-4 space-y-4 border-t pt-4">
+      <div class="modal__body border-t pt-4 space-y-4">
         <div class="flex items-center gap-2">
           <input id="order-comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
           <button id="btn-order-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>

--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -61,19 +61,19 @@
   </main>
 
   <!-- Modal Detalhes da Tarefa -->
-  <div id="task-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
-    <div class="bg-white rounded-lg shadow-lg w-11/12 max-w-2xl max-h-[90vh] overflow-y-auto">
-      <div class="flex justify-between items-center p-4 border-b">
+  <div id="task-modal" class="modal modal--task hidden" aria-modal="true" role="dialog">
+    <div class="modal__content">
+      <header class="modal__header">
         <div class="flex items-center gap-2">
-          <h3 class="text-lg font-semibold">Detalhes da Tarefa</h3>
-          <button id="task-order-chip" class="order-chip hidden" title=""></button>
+          <h3 class="modal__title">Detalhes da Tarefa</h3>
+          <button id="task-order-chip" class="chip hidden" title=""></button>
         </div>
-        <div class="flex items-center gap-2">
-          <button id="btn-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
-          <button id="btn-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+        <div class="modal__actions">
+          <button id="btn-edit" class="btn-ghost text-gray-600" aria-label="Editar"><i class="fas fa-pen"></i></button>
+          <button id="btn-close" class="text-gray-600 hover:text-gray-800" aria-label="Fechar"><i class="fas fa-times"></i></button>
         </div>
-      </div>
-      <form id="task-form" class="p-4 space-y-4 modal-read">
+      </header>
+      <form id="task-form" class="modal__body space-y-4 modal-read">
         <div>
           <label class="block text-sm font-medium">Título</label>
           <input id="task-titulo" class="w-full border rounded p-2" disabled />
@@ -95,7 +95,7 @@
           <button type="button" id="btn-complete" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
         </div>
       </form>
-      <div class="p-4 border-t space-y-4">
+      <div class="modal__body border-t space-y-4">
         <div class="flex items-center gap-2">
           <input id="comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
           <button id="btn-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
@@ -105,16 +105,16 @@
     </div>
   </div>
   <!-- Modal ordem reutilizado -->
-  <div id="order-modal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden" aria-modal="true" role="dialog">
-    <div class="bg-white rounded-xl shadow-lg w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto p-6">
-      <div class="flex justify-between items-center mb-4">
-        <h3 class="text-lg font-semibold">Detalhes da Ordem</h3>
-        <div class="flex items-center gap-2">
-          <button id="btn-order-edit" class="btn-ghost text-gray-600"><i class="fas fa-pen"></i></button>
-          <button id="btn-order-close" class="text-gray-600 hover:text-gray-800"><i class="fas fa-times"></i></button>
+  <div id="order-modal" class="modal modal--order hidden" aria-modal="true" role="dialog">
+    <div class="modal__content p-6">
+      <header class="modal__header">
+        <h3 class="modal__title">Detalhes da Ordem</h3>
+        <div class="modal__actions">
+          <button id="btn-order-edit" class="btn-ghost text-gray-600" aria-label="Editar"><i class="fas fa-pen"></i></button>
+          <button id="btn-order-close" class="text-gray-600 hover:text-gray-800" aria-label="Fechar"><i class="fas fa-times"></i></button>
         </div>
-      </div>
-      <form id="order-form" class="space-y-4 modal-read">
+      </header>
+      <form id="order-form" class="modal__body space-y-4 modal-read">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label for="order-codigo" class="block text-sm text-gray-600">Código</label>
@@ -161,7 +161,7 @@
           <button id="btn-order-new-task" class="btn-ghost text-sm text-blue-600 flex items-center gap-1"><i class="fas fa-plus"></i><span>Nova Tarefa</span></button>
         </div>
         <div class="mb-2">
-          <div class="task-progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div style="width:0%"></div></div>
+          <div class="progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div class="progress__bar" style="width:0%"></div></div>
           <div id="order-tasks-counter" class="text-xs text-gray-600 mt-1"></div>
         </div>
         <table class="w-full text-sm">
@@ -176,7 +176,7 @@
           <tbody id="order-tasks-list"></tbody>
         </table>
       </div>
-      <div class="mt-4 space-y-4 border-t pt-4">
+      <div class="modal__body border-t pt-4 space-y-4">
         <div class="flex items-center gap-2">
           <input id="order-comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
           <button id="btn-order-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
@@ -186,7 +186,7 @@
     </div>
   </div>
   <script type="module" src="js/ui/sidebar.js"></script>
-  <script type="module" src="js/pages/operador-ordens.js"></script>
+  <script type="module" src="js/ui/order-modal.js"></script>
   <script type="module" src="js/pages/operador-tarefas.js"></script>
   <script type="module" src="js/services/auth.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -24,9 +24,35 @@
     --space-3: 1.5rem;  /* 24px */
     --space-4: 2rem;    /* 32px */
 
-    --radius-base: 0.5rem;
-    --transition-base: 0.2s ease-in-out;
-}
+     --radius-base: 0.5rem;
+     --transition-base: 0.2s ease-in-out;
+
+     /* Design tokens */
+     --brand-600: #6C9F3D;
+     --brand-700: #5A8733;
+     --bg: #FFFFFF;
+     --panel: #FFFFFF;
+     --muted: #6B7280;
+     --border: #E5E7EB;
+     --shadow: 0 10px 30px rgba(0,0,0,.10);
+     --success-bg: #DCFCE7;
+     --success: #166534;
+     --success-border: #BBF7D0;
+     --warn-bg: #FEF9C3;
+     --warn: #854D0E;
+     --warn-border: #FEF08A;
+     --danger-bg: #FEE2E2;
+     --danger: #991B1B;
+     --danger-border: #FECACA;
+     --info-bg: #DBEAFE;
+     --info: #1E40AF;
+     --info-border: #BFDBFE;
+     --radius: 12px;
+     --radius-lg: 16px;
+     --gap: 16px;
+     --pad: 24px;
+     --input-h: 44px;
+ }
 
 [data-theme="dark"] {
     --text-dark: #f7fafc;
@@ -807,24 +833,8 @@ body.sidebar-open {
 }
 
 /* Chip ordem em tarefas */
-.order-chip {
-    display: inline-block;
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 2px 8px;
-    border-radius: 9999px;
-    background-color: #DBEAFE;
-    color: #1E40AF;
-    border: 1px solid #BFDBFE;
-}
-
-.order-chip:focus {
-    outline: 2px solid #1E40AF;
-    outline-offset: 2px;
-}
-
-/* Progresso de tarefas na tabela de ordens */
-.task-progress {
+/* Progress bar */
+.progress {
     width: 100%;
     height: 6px;
     border-radius: 9999px;
@@ -832,8 +842,128 @@ body.sidebar-open {
     overflow: hidden;
 }
 
-.task-progress > div {
+.progress__bar {
     height: 100%;
     background-color: #86EFAC;
     border-radius: 9999px;
+    width: 0;
+}
+
+/* Pill components */
+.pill {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 10px;
+    border: 1px solid;
+    border-radius: 9999px;
+    white-space: nowrap;
+}
+.pill--success {
+    background: var(--success-bg);
+    color: var(--success);
+    border-color: var(--success-border);
+}
+.pill--warn {
+    background: var(--warn-bg);
+    color: var(--warn);
+    border-color: var(--warn-border);
+}
+.pill--danger {
+    background: var(--danger-bg);
+    color: var(--danger);
+    border-color: var(--danger-border);
+}
+.pill--info {
+    background: var(--info-bg);
+    color: var(--info);
+    border-color: var(--info-border);
+}
+
+.chip {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 10px;
+    border: 1px solid var(--info-border);
+    border-radius: 9999px;
+    background: var(--info-bg);
+    color: var(--info);
+    white-space: nowrap;
+    cursor: pointer;
+}
+.chip:hover {
+    filter: brightness(0.95);
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.modal__content {
+    background: var(--panel);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    width: 100%;
+    max-height: 90vh;
+    overflow: hidden;
+}
+.modal--task .modal__content {
+    max-width: 920px;
+}
+.modal--order .modal__content {
+    max-width: 1040px;
+}
+.modal__header {
+    position: sticky;
+    top: 0;
+    padding: 16px 24px;
+    background: #FFF;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.modal__body {
+    padding: var(--pad);
+    max-height: 70vh;
+    overflow-y: auto;
+}
+.modal__title {
+    font-size: 1rem;
+    font-weight: 600;
+}
+.modal__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: var(--gap);
+}
+.field__label {
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 4px;
+}
+.field__input {
+    height: var(--input-h);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0 12px;
+}
+.field__input:focus {
+    box-shadow: 0 0 0 3px rgba(108,159,61,.28);
+    outline: none;
+    border-color: var(--brand-600);
+}
+.field__error {
+    font-size: 12px;
+    color: var(--danger);
+    margin-top: 4px;
 }


### PR DESCRIPTION
## Summary
- add design tokens and reusable pill, chip, modal, and progress styles
- introduce standalone order modal script with task list and task-modal integration
- switch operator pages to new modal markup and progress components

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689caf049d74832ebac7b9fc5a496329