### PR TITLE
Add responsive dashboard task modal bindings

### DIFF
--- a/public/js/pages/operador-dashboard.js
+++ b/public/js/pages/operador-dashboard.js
@@ -48,8 +48,24 @@ if (window.Chart) {
   Chart.register(barValuePlugin);
 }
 
-export async function initOperadorDashboard(userId) {
+document.addEventListener('DOMContentLoaded', () => {
   initTaskModal();
+  const tbl = document.getElementById('dashboard-tasks-table');
+  if (tbl && !tbl.__bound) {
+    tbl.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-action="view-task"], .js-view-task');
+      if (!btn) return;
+      e.preventDefault();
+      const taskId = btn.dataset.taskId || btn.dataset.id;
+      if (!taskId) return;
+      document.body.classList.remove('drawer-open');
+      openTaskModal(taskId, { mode: 'view' });
+    });
+    tbl.__bound = true;
+  }
+});
+
+export async function initOperadorDashboard(userId) {
   await loadFarmId(userId);
   window.taskModalFarmId = state.farmClientId;
   bindUI();
@@ -171,19 +187,12 @@ function renderTable() {
       <td class="px-3 py-3 h-12 min-w-[112px]">${formatDate(t.dueDate)}</td>
       <td class="px-3 py-3 h-12 min-w-[120px]">${statusHtml}</td>
       <td class="px-3 py-3 h-12">
-        <button class="details-btn px-2 py-1 text-sm text-blue-700 border border-blue-700 rounded hover:bg-blue-700 hover:text-white flex items-center gap-1" data-id="${t.id}">
+        <button type="button" class="details-btn px-2 py-1 text-sm text-blue-700 border border-blue-700 rounded hover:bg-blue-700 hover:text-white flex items-center gap-1 js-view-task" data-action="view-task" data-task-id="${t.id}">
           <i class="fas fa-eye"></i><span>Ver detalhes</span>
         </button>
       </td>
     `;
     tbody.appendChild(tr);
-  });
-
-  tbody.querySelectorAll('.details-btn').forEach(btn => {
-    btn.onclick = e => {
-      const id = e.currentTarget.getAttribute('data-id');
-      openTaskModal(id, 'table');
-    };
   });
 }
 

--- a/public/js/ui/task-modal.js
+++ b/public/js/ui/task-modal.js
@@ -25,10 +25,10 @@ let creatingTask = false;
 
 export function initTaskModal() {
   if (window.__taskModalInited) return;
+  window.__taskModalInited = true;
   overlay = document.getElementById('task-modal-overlay');
   const modal = overlay?.querySelector('.modal');
   if (!overlay || !modal) return;
-  window.__taskModalInited = true;
   document.getElementById('btn-edit')?.addEventListener('click', enterEditMode);
   document.getElementById('task-form')?.addEventListener('submit', e => {
     e.preventDefault();

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -39,17 +39,18 @@
   </aside>
 
     <main class="main-content">
-      <header class="dashboard-header">
-        <h1 class="text-lg font-semibold">Dashboard do Operador</h1>
-        <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
-      </header>
+      <div class="page-container">
+        <header class="dashboard-header">
+          <h1 class="text-lg font-semibold">Dashboard do Operador</h1>
+          <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
+        </header>
 
     <!-- CONTEÚDO PRINCIPAL -->
     <div class="dashboard-container flex flex-col pt-4 pb-6">
 
     <!-- KPIS -->
-      <section class="dashboard-section flex flex-col gap-4 mb-6 kpi-grid">
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+      <section class="dashboard-section mb-6">
+        <div class="stats-grid">
           <div class="dashboard-card flex items-center gap-3">
             <i class="fas fa-calendar-check text-[20px] text-gray-500"></i>
             <div class="flex flex-col">
@@ -64,8 +65,6 @@
               <p id="monthNew" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
             </div>
           </div>
-        </div>
-        <div id="kpis-linha-2" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           <div class="dashboard-card flex items-center gap-3">
             <i class="fas fa-circle-check text-[20px] text-gray-500"></i>
             <div class="flex flex-col">
@@ -91,7 +90,7 @@
       </section>
 
     <!-- GRADE: GRÁFICOS -->
-    <section id="dash-graphs-row" class="dashboard-section mb-6">
+    <section id="dash-graphs-row" class="dashboard-section mb-6 chart-grid">
       <!-- GRÁFICO -->
       <section class="dashboard-card flex flex-col p-5 min-w-0">
         <h3 class="text-lg font-semibold mb-4">Resumo de Tarefas</h3>
@@ -135,8 +134,8 @@
             </button>
           </div>
         </div>
-        <div class="overflow-x-auto md:overflow-x-visible">
-          <table class="w-full table-auto text-left text-sm">
+        <div class="table-responsive">
+          <table id="dashboard-tasks-table" class="tasks-table w-full table-auto text-left text-sm">
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Título</th>
@@ -148,11 +147,12 @@
             </thead>
             <tbody id="tasksTableBody"></tbody>
           </table>
-          <p id="emptyState" class="hidden text-center py-4">Nenhuma tarefa cadastrada</p>
         </div>
+        <p id="emptyState" class="hidden text-center py-4">Nenhuma tarefa cadastrada</p>
       </section>
     </section>
     </div>
+  </div>
   </main>
 
     <div id="taskModal" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center hidden">

--- a/public/style.css
+++ b/public/style.css
@@ -47,9 +47,47 @@
      --radius: 12px;
      --radius-lg: 16px;
      --gap: 16px;
-     --pad: 20px;
+     --pad: 16px;
+     --pad-lg: 24px;
      --input-h: 44px;
- }
+}
+
+.page-container{
+  max-width:1200px;
+  margin:0 auto;
+  padding:0 var(--pad);
+  padding-left:max(var(--pad), env(safe-area-inset-left));
+  padding-right:max(var(--pad), env(safe-area-inset-right));
+}
+@media (min-width:768px){
+  .page-container{
+    padding:0 var(--pad-lg);
+    padding-left:max(var(--pad-lg), env(safe-area-inset-left));
+    padding-right:max(var(--pad-lg), env(safe-area-inset-right));
+  }
+}
+
+.stats-grid{
+  display:grid;
+  gap:var(--gap);
+  grid-template-columns:repeat(4,1fr);
+}
+@media (max-width:1023px){.stats-grid{grid-template-columns:repeat(2,1fr);}}
+@media (max-width:599px){.stats-grid{grid-template-columns:1fr;}}
+
+.chart-grid{
+  display:grid;
+  gap:var(--gap);
+  grid-template-columns:2fr 1fr;
+}
+@media (max-width:1023px){.chart-grid{grid-template-columns:1fr;}}
+
+.table-responsive{overflow-x:auto;}
+table{min-width:560px;}
+@media (max-width:480px){.tasks-table td:last-child .btn{width:100%;height:44px;}}
+
+.btn{min-height:44px;}
+.select,.input{height:var(--input-h);}
 
 [data-theme="dark"] {
     --text-dark: #f7fafc;


### PR DESCRIPTION
## Summary
- Wrap operador dashboard content in `.page-container` and apply new `.stats-grid` and `.chart-grid` layouts
- Make tasks table responsive with delegated "Ver detalhes" buttons opening the task modal in view mode
- Ensure task modal initializes only once and add mobile-friendly spacing tokens

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cc3b0e428832e8bb8aae7b38a7266