### PR TITLE
style: align order modal and kpi layout

### DIFF
--- a/public/js/pages/operador-dashboard.js
+++ b/public/js/pages/operador-dashboard.js
@@ -211,9 +211,9 @@ function renderMetrics() {
     const monthCompleted = state.allTasks.filter(t => t.isCompleted && sameMonth(t.completedAt)).length;
     const monthNew = state.allTasks.filter(t => sameMonth(t.createdAt)).length;
 
-    const totalPendingEl = document.getElementById('totalPending');
-    const totalDelayedEl = document.getElementById('totalDelayed');
-    const totalCompletedEl = document.getElementById('totalCompleted');
+    const totalPendingEl = document.getElementById('kpi-pendentes');
+    const totalDelayedEl = document.getElementById('kpi-atrasadas');
+    const totalCompletedEl = document.getElementById('kpi-concluidas');
     const monthCompletedEl = document.getElementById('monthCompleted');
     const monthNewEl = document.getElementById('monthNew');
 

--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -8,7 +8,7 @@ import {
   onSnapshot,
   Timestamp
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
-import { parseDateLocal, formatDDMMYYYY, endOfLocalDay } from '../lib/date-utils.js';
+import { parseDateLocal, formatDDMMYYYY, endOfLocalDay, toYYYYMMDD } from '../lib/date-utils.js';
 import { openTaskModal } from './task-modal.js';
 
 let overlay;
@@ -62,16 +62,11 @@ export async function openOrderModal(orderId) {
   const snap = await getDoc(orderRef);
   if (snap.exists()) {
     const data = snap.data();
-    currentOrder.codigo = data.codigo || orderId;
-    currentOrder.prazo = data.prazo || '';
-    document.getElementById('order-codigo').value = currentOrder.codigo;
-    document.getElementById('order-cliente').value = data.cliente || '';
-    document.getElementById('order-propriedade').value = data.propriedade || '';
-    document.getElementById('order-talhao').value = data.talhao || '';
-    document.getElementById('order-abertura').value = data.abertura || '';
-    document.getElementById('order-prazo').value = data.prazo || '';
-    document.getElementById('order-itens').value = data.itens || '';
-    document.getElementById('order-obs').value = data.obs || '';
+    currentOrder = { id: orderId, ...data, codigo: data.codigo || orderId, prazo: data.prazo || '' };
+    fillOrderForm(currentOrder);
+  } else {
+    currentOrder.codigo = orderId;
+    fillOrderForm(currentOrder);
   }
   loadTasks(orderId);
   overlay.hidden = false;
@@ -137,6 +132,20 @@ function renderTaskStatus(st) {
 
 function nowLocal() {
   return new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' }));
+}
+
+function fillOrderForm(order) {
+  document.getElementById('order-codigo').value = order.codigo || '';
+  document.getElementById('order-cliente').value = order.cliente || '';
+  document.getElementById('order-propriedade').value = order.propriedade || '';
+  document.getElementById('order-talhao').value = order.talhao || '';
+  const ab = document.getElementById('order-abertura');
+  ab.value = order.abertura ? toYYYYMMDD(parseDateLocal(order.abertura)) : '';
+  const prazo = document.getElementById('order-prazo');
+  prazo.value = order.prazo ? toYYYYMMDD(parseDateLocal(order.prazo)) : '';
+  document.getElementById('order-itens').value = order.itens || '';
+  document.getElementById('order-total').value = order.total || '';
+  document.getElementById('order-obs').value = order.obs || '';
 }
 
 window.openOrderModal = openOrderModal;

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -50,7 +50,7 @@
 
     <!-- KPIS -->
       <section class="dashboard-section mb-6">
-        <div class="stats-grid">
+        <div class="stats-grid mb-6">
           <div class="dashboard-card flex items-center gap-3">
             <i class="fas fa-calendar-check text-[20px] text-gray-500"></i>
             <div class="flex flex-col">
@@ -65,25 +65,27 @@
               <p id="monthNew" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
             </div>
           </div>
-          <div class="dashboard-card flex items-center gap-3">
-            <i class="fas fa-circle-check text-[20px] text-gray-500"></i>
-            <div class="flex flex-col">
-              <p class="text-xs text-gray-500">Concluídas</p>
-              <p id="totalCompleted" class="kpi-value skeleton text-[28px] font-bold text-[#166534]"></p>
+        </div>
+        <div class="kpi-row" id="kpi-status-row">
+          <div class="kpi-card">
+            <div class="kpi-icon"><i class="fas fa-circle-check text-[20px] text-gray-500"></i></div>
+            <div class="kpi-text">
+              <span class="kpi-title">Concluídas</span>
+              <span id="kpi-concluidas" class="kpi-value skeleton text-[#166534]"></span>
             </div>
           </div>
-          <div class="dashboard-card flex items-center gap-3">
-            <i class="fas fa-clock text-[20px] text-gray-500"></i>
-            <div class="flex flex-col">
-              <p class="text-xs text-gray-500">Pendentes</p>
-              <p id="totalPending" class="kpi-value skeleton text-[28px] font-bold text-[#92400E]"></p>
+          <div class="kpi-card">
+            <div class="kpi-icon"><i class="fas fa-clock text-[20px] text-gray-500"></i></div>
+            <div class="kpi-text">
+              <span class="kpi-title">Pendentes</span>
+              <span id="kpi-pendentes" class="kpi-value skeleton text-[#92400E]"></span>
             </div>
           </div>
-          <div class="dashboard-card flex items-center gap-3">
-            <i class="fas fa-triangle-exclamation text-[20px] text-gray-500"></i>
-            <div class="flex flex-col">
-              <p class="text-xs text-gray-500">Atrasadas</p>
-              <p id="totalDelayed" class="kpi-value skeleton text-[28px] font-bold text-[#991B1B]"></p>
+          <div class="kpi-card">
+            <div class="kpi-icon"><i class="fas fa-triangle-exclamation text-[20px] text-gray-500"></i></div>
+            <div class="kpi-text">
+              <span class="kpi-title">Atrasadas</span>
+              <span id="kpi-atrasadas" class="kpi-value skeleton text-[#991B1B]"></span>
             </div>
           </div>
         </div>

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -155,43 +155,43 @@
         </div>
       </header>
       <form id="order-form" class="modal__body space-y-4 modal-read">
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label for="order-codigo" class="block text-sm text-gray-600">Código</label>
-            <input id="order-codigo" class="w-full border rounded p-2" disabled />
+        <div class="modal__grid-2">
+          <div class="field">
+            <label for="order-codigo" class="field__label">Código</label>
+            <input id="order-codigo" class="field__input" readonly />
           </div>
-          <div>
-            <label for="order-cliente" class="block text-sm text-gray-600">Cliente</label>
-            <input id="order-cliente" class="w-full border rounded p-2" disabled />
+          <div class="field">
+            <label for="order-cliente" class="field__label">Cliente</label>
+            <input id="order-cliente" class="field__input" readonly />
           </div>
-          <div>
-            <label for="order-propriedade" class="block text-sm text-gray-600">Propriedade</label>
-            <input id="order-propriedade" class="w-full border rounded p-2" disabled />
+          <div class="field">
+            <label for="order-propriedade" class="field__label">Propriedade</label>
+            <input id="order-propriedade" class="field__input" readonly />
           </div>
-          <div>
-            <label for="order-talhao" class="block text-sm text-gray-600">Talhão</label>
-            <input id="order-talhao" class="w-full border rounded p-2" disabled />
+          <div class="field">
+            <label for="order-talhao" class="field__label">Talhão</label>
+            <input id="order-talhao" class="field__input" readonly />
           </div>
-          <div>
-            <label for="order-abertura" class="block text-sm text-gray-600">Abertura</label>
-            <input id="order-abertura" class="w-full border rounded p-2" disabled />
+          <div class="field">
+            <label for="order-abertura" class="field__label">Abertura</label>
+            <input id="order-abertura" class="field__input" readonly />
           </div>
-          <div>
-            <label for="order-prazo" class="block text-sm text-gray-600">Prazo</label>
-            <input id="order-prazo" type="date" class="w-full border rounded p-2" disabled />
+          <div class="field">
+            <label for="order-prazo" class="field__label">Prazo</label>
+            <input id="order-prazo" type="date" class="field__input" readonly />
           </div>
         </div>
-        <div>
-          <label for="order-itens" class="block text-sm text-gray-600">Itens</label>
-          <textarea id="order-itens" class="w-full border rounded p-2" rows="3" disabled></textarea>
+        <div class="field">
+          <label for="order-itens" class="field__label">Itens</label>
+          <textarea id="order-itens" class="field__input" rows="3" readonly></textarea>
         </div>
-        <div>
-          <label for="order-total" class="block text-sm text-gray-600">Total (R$)</label>
-          <input id="order-total" class="w-full border rounded p-2 text-right" disabled />
+        <div class="field">
+          <label for="order-total" class="field__label">Total (R$)</label>
+          <input id="order-total" class="field__input text-right" readonly />
         </div>
-        <div>
-          <label for="order-obs" class="block text-sm text-gray-600">Observações</label>
-          <textarea id="order-obs" class="w-full border rounded p-2" rows="3" disabled></textarea>
+        <div class="field">
+          <label for="order-obs" class="field__label">Observações</label>
+          <textarea id="order-obs" class="field__input" rows="3" readonly></textarea>
         </div>
       <div class="flex justify-end gap-2 pt-2">
         <button type="button" id="btn-order-save" class="hidden bg-[#6C9F3D] hover:bg-[#5A8733] text-white px-4 py-2 rounded">Salvar</button>
@@ -200,25 +200,27 @@
       </div>
       </form>
       <div id="order-tasks" class="mt-6">
-        <div class="flex justify-between items-center mb-2">
-          <h4 class="text-sm font-semibold">Tarefas desta ordem</h4>
-          <button id="btn-order-new-task" type="button" aria-label="Criar nova tarefa desta ordem" title="Criar nova tarefa desta ordem" class="btn-ghost text-sm text-blue-600 flex items-center gap-1"><i class="fas fa-plus"></i><span>Nova Tarefa</span></button>
+        <div class="section-header">
+          <h3>Tarefas desta ordem</h3>
+          <button id="btn-order-new-task" type="button" class="btn btn-ghost">+ Nova Tarefa</button>
         </div>
         <div class="mb-2">
           <div class="progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div class="progress__bar" style="width:0%"></div></div>
           <div id="order-tasks-counter" class="text-xs text-gray-600 mt-1" aria-live="polite"></div>
         </div>
-        <table class="w-full text-sm">
-          <thead class="bg-gray-50">
-            <tr>
-              <th scope="col" class="px-2 py-2 text-left">Título</th>
-              <th scope="col" class="px-2 py-2 text-left">Vencimento</th>
-              <th scope="col" class="px-2 py-2 text-left">Status</th>
-              <th scope="col" class="px-2 py-2 text-left">Ações</th>
-            </tr>
-          </thead>
-          <tbody id="order-tasks-list"></tbody>
-        </table>
+        <div class="table-responsive">
+          <table class="w-full text-sm">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="px-2 py-2 text-left">Título</th>
+                <th scope="col" class="px-2 py-2 text-left">Vencimento</th>
+                <th scope="col" class="px-2 py-2 text-left">Status</th>
+                <th scope="col" class="px-2 py-2 text-left">Ações</th>
+              </tr>
+            </thead>
+            <tbody id="order-tasks-list"></tbody>
+          </table>
+        </div>
       </div>
       <div class="modal__body border-t pt-4 space-y-4">
         <div class="flex items-center gap-2">

--- a/public/style.css
+++ b/public/style.css
@@ -82,8 +82,9 @@
 }
 @media (max-width:1023px){.chart-grid{grid-template-columns:1fr;}}
 
+/* Tabela de tarefas dentro do modal responsiva */
 .table-responsive{overflow-x:auto;}
-table{min-width:560px;}
+.table-responsive table{min-width:600px;}
 @media (max-width:480px){.tasks-table td:last-child .btn{width:100%;height:44px;}}
 
 .btn{min-height:44px;}
@@ -898,6 +899,7 @@ body.has-modal {
     box-shadow: 0 20px 60px rgba(0,0,0,.20);
     max-width: 1040px;
     width: 100%;
+    margin: 0 auto;
     max-height: 85vh;
     display: flex;
     flex-direction: column;
@@ -907,7 +909,7 @@ body.has-modal {
     top: 0;
     background: #FFF;
     z-index: 1;
-    padding: 16px 20px;
+    padding: 16px 24px;
     box-shadow: 0 1px 0 #E5E7EB;
     display: flex;
     align-items: center;
@@ -915,7 +917,7 @@ body.has-modal {
 }
 .modal__body {
     overflow: auto;
-    padding: 20px;
+    padding: 20px 24px;
 }
 .modal__title {
     font-size: 1rem;
@@ -934,20 +936,32 @@ body.has-modal {
 @media(max-width:1024px){
     .modal__grid{grid-template-columns:1fr}
 }
+/* Grid de 2 colunas no desktop, 1 coluna no mobile */
+.modal__grid-2{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:16px;
+}
+@media (max-width:1023px){
+  .modal__grid-2{grid-template-columns:1fr;}
+}
 .field {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    min-width:0;
 }
 .field__label {
     font-size: 12px;
     color: var(--muted);
 }
 .field__input {
+    width:100%;
     height: var(--input-h);
     border: 1px solid var(--border);
     border-radius: 10px;
     padding: 0 12px;
+    box-sizing:border-box;
 }
 .field__input:focus {
     outline: none;
@@ -963,3 +977,27 @@ textarea.field__input {
     color: var(--danger);
     margin-top: 4px;
 }
+
+.field__input[readonly]{background:#F9FAFB;color:#111827;opacity:1;}
+
+/* Cabeçalho de seção com ação à direita */
+.section-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:8px;margin-bottom:8px;}
+
+/* Evitar que o scrollbar do body mude a largura do modal */
+body.has-modal{overflow:hidden;}
+
+/* KPIs em linha */
+.kpi-row{
+  display:grid;gap:16px;
+  grid-template-columns:repeat(3,minmax(200px,1fr));
+}
+@media (max-width:767px){
+  .kpi-row{grid-template-columns:1fr;}
+}
+
+/* Padroniza altura e alinhamento dos cards */
+.kpi-card{min-height:88px;border:1px solid #E5E7EB;border-radius:12px;padding:16px;display:flex;align-items:center;gap:12px;}
+.kpi-card .kpi-icon{flex:0 0 36px;height:36px;display:grid;place-items:center;border-radius:50%;background:#F3F4F6;}
+.kpi-card .kpi-text{display:flex;flex-direction:column;gap:2px;}
+.kpi-card .kpi-title{font-size:12px;color:#6B7280;}
+.kpi-card .kpi-value{font-weight:700;font-size:24px;line-height:1;}


### PR DESCRIPTION
## Summary
- improve order detail modal layout with two-column grid, responsive table and section header
- display KPI status cards in responsive row on operator dashboard
- populate order modal fields without placeholders

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ccf96b980832ea671f10b6a6cf4ef