### PR TITLE
Improve operator order modal layout and task section

### DIFF
--- a/public/js/pages/operador-ordens.js
+++ b/public/js/pages/operador-ordens.js
@@ -313,9 +313,9 @@ function renderStatus(status) {
 
 function openModal(order, mode = 'view') {
   state.current = order;
-  fillForm(order);
-  renderComments();
   modal.dataset.mode = mode;
+  fillForm(order, mode);
+  renderComments();
   form.dataset.dirty = 'false';
   if (mode === 'create') {
     form.classList.remove('modal-read');
@@ -333,7 +333,7 @@ function openModal(order, mode = 'view') {
     toggleFormFields(true);
     document.getElementById('btn-order-save').classList.add('hidden');
     document.getElementById('btn-order-conclude').classList.remove('hidden');
-     document.getElementById('btn-order-cancel').classList.remove('hidden');
+    document.getElementById('btn-order-cancel').classList.remove('hidden');
     document.getElementById('btn-order-edit').classList.remove('hidden');
     document.getElementById('btn-order-duplicate').classList.remove('hidden');
     document.getElementById('order-modal-title').textContent = 'Detalhes da Ordem';
@@ -522,19 +522,44 @@ function renderComments() {
   });
 }
 
-function fillForm(o) {
-  document.getElementById('order-codigo').value = o.id || '';
-  document.getElementById('order-cliente').value = o.cliente || '';
-  document.getElementById('order-propriedade').value = o.propriedade || '';
-  document.getElementById('order-talhao').value = o.talhao || '';
-  document.getElementById('order-abertura').value = o.abertura || '';
-  document.getElementById('order-prazo').value = o.prazo || '';
-  document.getElementById('order-itens').value = o.itens || '';
+function fillForm(o, mode = 'view') {
+  const codeChip = document.getElementById('order-code-chip');
+  if (codeChip) {
+    codeChip.textContent = o.id || '';
+    codeChip.classList.toggle('hidden', !o.id);
+  }
+  const statusChip = document.getElementById('order-status-chip');
+  if (statusChip) {
+    const st = o.status || '';
+    statusChip.textContent = st || '—';
+    const cls = st
+      ? st === 'Concluída'
+        ? 'pill pill--success'
+        : st === 'Cancelada'
+          ? 'pill pill--danger'
+          : st === 'Em andamento'
+            ? 'pill pill--warn'
+            : 'pill pill--info'
+      : 'pill';
+    statusChip.className = cls;
+  }
+  document.getElementById('order-codigo').value = o.id || '—';
+  document.getElementById('order-cliente').value = o.cliente || (mode === 'view' ? '—' : '');
+  document.getElementById('order-propriedade').value = o.propriedade || (mode === 'view' ? '—' : '');
+  document.getElementById('order-talhao').value = o.talhao || (mode === 'view' ? '—' : '');
+  const aberturaEl = document.getElementById('order-abertura');
+  aberturaEl.type = 'text';
+  aberturaEl.value = o.abertura || '—';
+  const prazoEl = document.getElementById('order-prazo');
+  prazoEl.type = mode === 'view' ? 'text' : 'date';
+  prazoEl.value = o.prazo || '';
+  document.getElementById('order-itens').value = o.itens || (mode === 'view' ? '—' : '');
   document.getElementById('order-total').value = (o.total || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-  document.getElementById('order-obs').value = o.obs || '';
+  document.getElementById('order-obs').value = o.obs || (mode === 'view' ? '—' : '');
   document.getElementById('order-total').disabled = true;
-  toggleFormFields(true);
-  document.getElementById('btn-order-save').classList.add('hidden');
+  toggleFormFields(mode === 'view');
+  if (mode !== 'view') document.getElementById('btn-order-save').classList.remove('hidden');
+  else document.getElementById('btn-order-save').classList.add('hidden');
 }
 
 function toggleFormFields(disabled) {

--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -93,15 +93,17 @@ function loadTasks(orderId) {
         <td>${data.title || d.id}</td>
         <td>${dueDate ? formatDDMMYYYY(dueDate) : '-'}</td>
         <td>${renderTaskStatus(status)}</td>
-        <td><button type="button" class="btn-ghost text-blue-700" data-action="view-task" data-task-id="${d.id}">Ver detalhes</button></td>`;
+        <td class="text-right"><button type="button" class="btn-ghost text-blue-700 whitespace-nowrap" data-action="view-task" data-task-id="${d.id}">Ver detalhes</button></td>`;
       frag.appendChild(tr);
     });
     list?.replaceChildren(frag);
     const counter = document.getElementById('order-tasks-counter');
     if (counter) counter.textContent = `${open}/${total} abertas`;
-    const bar = document.querySelector('#order-tasks .progress__bar');
+    const bar = document.querySelector('#order-tasks .progress');
+    const barFill = bar?.querySelector('.progress__bar');
     const percent = total ? (completed / total) * 100 : 0;
-    if (bar) bar.style.width = `${percent}%`;
+    if (barFill) barFill.style.width = `${percent}%`;
+    if (bar) bar.setAttribute('aria-label', `Progresso de tarefas: ${completed} de ${total} concluídas`);
   });
 }
 
@@ -135,17 +137,41 @@ function nowLocal() {
 }
 
 function fillOrderForm(order) {
-  document.getElementById('order-codigo').value = order.codigo || '';
-  document.getElementById('order-cliente').value = order.cliente || '';
-  document.getElementById('order-propriedade').value = order.propriedade || '';
-  document.getElementById('order-talhao').value = order.talhao || '';
+  const codeEl = document.getElementById('order-code-chip');
+  if (codeEl) {
+    codeEl.textContent = order.codigo || order.id || '';
+    codeEl.classList.toggle('hidden', !(order.codigo || order.id));
+  }
+  const statusEl = document.getElementById('order-status-chip');
+  if (statusEl) {
+    const st = order.status || '';
+    statusEl.textContent = st || '—';
+    const cls = st
+      ? st === 'Concluída'
+        ? 'pill pill--success'
+        : st === 'Cancelada'
+          ? 'pill pill--danger'
+          : st === 'Em andamento'
+            ? 'pill pill--warn'
+            : 'pill pill--info'
+      : 'pill';
+    statusEl.className = cls;
+  }
+  document.getElementById('order-codigo').value = order.codigo || order.id || '—';
+  document.getElementById('order-cliente').value = order.cliente || '—';
+  document.getElementById('order-propriedade').value = order.propriedade || '—';
+  document.getElementById('order-talhao').value = order.talhao || '—';
   const ab = document.getElementById('order-abertura');
-  ab.value = order.abertura ? toYYYYMMDD(parseDateLocal(order.abertura)) : '';
+  ab.type = 'text';
+  ab.value = order.abertura ? formatDDMMYYYY(parseDateLocal(order.abertura)) : '—';
   const prazo = document.getElementById('order-prazo');
-  prazo.value = order.prazo ? toYYYYMMDD(parseDateLocal(order.prazo)) : '';
-  document.getElementById('order-itens').value = order.itens || '';
-  document.getElementById('order-total').value = order.total || '';
-  document.getElementById('order-obs').value = order.obs || '';
+  prazo.type = 'text';
+  prazo.value = order.prazo ? formatDDMMYYYY(parseDateLocal(order.prazo)) : '—';
+  document.getElementById('order-itens').value = order.itens || '—';
+  document.getElementById('order-total').value = typeof order.total === 'number'
+    ? order.total.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+    : '—';
+  document.getElementById('order-obs').value = order.obs || '—';
 }
 
 window.openOrderModal = openOrderModal;

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -147,7 +147,11 @@
   <div class="modal-overlay" id="order-modal-overlay" hidden>
     <div class="modal" id="order-modal" data-mode="view" role="dialog" aria-modal="true" aria-labelledby="order-modal-title">
       <header class="modal__header">
-        <h3 id="order-modal-title" class="modal__title">Detalhes da Ordem</h3>
+        <div class="flex items-center gap-2">
+          <h3 id="order-modal-title" class="modal__title">Detalhes da Ordem</h3>
+          <span id="order-status-chip" class="pill"></span>
+          <span id="order-code-chip" class="pill pill--info"></span>
+        </div>
         <div class="modal__actions">
           <button id="btn-order-duplicate" class="btn-ghost text-gray-600" title="Duplicar"><i class="fas fa-copy"></i></button>
           <button id="btn-order-edit" class="btn-ghost text-gray-600" aria-label="Editar"><i class="fas fa-pen"></i></button>
@@ -178,7 +182,7 @@
           </div>
           <div class="field">
             <label for="order-prazo" class="field__label">Prazo</label>
-            <input id="order-prazo" type="date" class="field__input" readonly />
+            <input id="order-prazo" class="field__input" readonly />
           </div>
         </div>
         <div class="field">
@@ -200,22 +204,22 @@
       </div>
       </form>
       <div id="order-tasks" class="mt-6">
-        <div class="section-header">
-          <h3>Tarefas desta ordem</h3>
-          <button id="btn-order-new-task" type="button" class="btn btn-ghost">+ Nova Tarefa</button>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <h3 class="text-base font-semibold">Tarefas desta ordem</h3>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+            <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap">0/0 abertas</span>
+            <div class="progress" style="--progress-width:128px" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div class="progress__bar"></div></div>
+            <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap">+ Nova Tarefa</button>
+          </div>
         </div>
-        <div class="mb-2">
-          <div class="progress" aria-label="Progresso de tarefas: 0 de 0 concluídas"><div class="progress__bar" style="width:0%"></div></div>
-          <div id="order-tasks-counter" class="text-xs text-gray-600 mt-1" aria-live="polite"></div>
-        </div>
-        <div class="table-responsive">
+        <div class="table-responsive mt-2">
           <table class="w-full text-sm">
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="px-2 py-2 text-left">Título</th>
                 <th scope="col" class="px-2 py-2 text-left">Vencimento</th>
                 <th scope="col" class="px-2 py-2 text-left">Status</th>
-                <th scope="col" class="px-2 py-2 text-left">Ações</th>
+                <th scope="col" class="px-2 py-2 text-right">Ações</th>
               </tr>
             </thead>
             <tbody id="order-tasks-list"></tbody>

--- a/public/style.css
+++ b/public/style.css
@@ -844,7 +844,7 @@ body.has-modal {
 /* Chip ordem em tarefas */
 /* Progress bar */
 .progress {
-    width: 100%;
+    width: var(--progress-width, 100%);
     height: 6px;
     border-radius: 9999px;
     background-color: #E5E7EB;


### PR DESCRIPTION
## Summary
- Show order status and code chips in modal header with read-only fields formatted for empty values
- Restructure "Tarefas desta ordem" header with counter, progress bar and responsive new task action; ensure task action button stays on one line
- Support fixed-width progress bar via CSS variable and adjust scripts to update counters and progress accessibility

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_689cd5918320832e99fe441c7cbb306a