### PR TITLE
Refatora tarefas no modal de ordem para layout responsivo

### DIFF
--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -159,10 +159,10 @@ function renderTaskList() {
     const tr = document.createElement('tr');
     const dueText = t.dueDate ? formatDDMMYYYY(t.dueDate) : '-';
     tr.innerHTML = `
-      <td>${t.title}</td>
-      <td>${dueText}</td>
-      <td>${renderTaskStatus(t.status)}</td>
-      <td class="text-right"><button type="button" class="btn-ghost text-blue-700 whitespace-nowrap" data-action="view-task" data-task-id="${t.id}">Ver detalhes</button></td>`;
+      <td class="min-w-[280px]">${t.title}</td>
+      <td class="text-center min-w-[120px] whitespace-nowrap">${dueText}</td>
+      <td class="text-center min-w-[140px]">${renderTaskStatus(t.status)}</td>
+      <td class="text-right min-w-[160px]"><button type="button" class="btn btn-ghost text-blue-700 whitespace-nowrap" data-action="view-task" data-task-id="${t.id}">Ver detalhes</button></td>`;
     frag.appendChild(tr);
   });
   list.replaceChildren(frag);

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -204,12 +204,14 @@
       </div>
       </form>
       <div id="order-tasks" class="mt-6">
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <h3 class="text-base font-semibold">Tarefas desta ordem</h3>
-          <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
-            <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap" aria-live="polite">0/0 abertas</span>
-            <div class="progress" style="--progress-width:160px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite"><div class="progress__bar"></div></div>
-            <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap">+ Nova Tarefa</button>
+        <div class="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-start md:gap-4 lg:flex-nowrap lg:items-center lg:justify-between">
+          <h3 class="text-base font-semibold md:w-full lg:w-auto">Tarefas desta ordem</h3>
+          <div class="flex flex-col gap-4 md:flex-row md:flex-nowrap md:items-center md:justify-end md:gap-4">
+            <div class="flex items-center gap-3">
+              <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap" aria-live="polite">0/0 abertas</span>
+              <div class="progress" style="--progress-width:160px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite"><div class="progress__bar"></div></div>
+            </div>
+            <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap w-full md:w-auto">+ Nova Tarefa</button>
           </div>
         </div>
         <div id="order-tasks-filters" class="flex flex-wrap gap-2 mt-3">
@@ -218,14 +220,14 @@
           <button type="button" class="chip chip--filter" data-filter="Atrasada">Atrasadas <span class="count">0</span></button>
           <button type="button" class="chip chip--filter" data-filter="Concluída">Concluídas <span class="count">0</span></button>
         </div>
-        <div id="order-tasks-table" class="table-responsive mt-4">
+        <div id="order-tasks-table" class="table-responsive w-full mt-2">
           <table class="w-full text-sm">
             <thead class="bg-gray-50">
               <tr>
-                <th scope="col" class="px-2 py-2 text-left">Título</th>
-                <th scope="col" class="px-2 py-2 text-center">Vencimento</th>
-                <th scope="col" class="px-2 py-2 text-center">Status</th>
-                <th scope="col" class="px-2 py-2 text-right">Ações</th>
+                <th scope="col" class="px-2 py-2 text-left min-w-[280px]">Título</th>
+                <th scope="col" class="px-2 py-2 text-center min-w-[120px]">Vencimento</th>
+                <th scope="col" class="px-2 py-2 text-center min-w-[140px]">Status</th>
+                <th scope="col" class="px-2 py-2 text-right min-w-[160px]">Ações</th>
               </tr>
             </thead>
             <tbody id="order-tasks-list"></tbody>
@@ -233,7 +235,7 @@
         </div>
         <div id="order-tasks-empty" class="hidden mt-4 text-sm text-gray-600 flex items-center gap-2">
           Nenhuma tarefa nesta ordem ainda
-          <button type="button" id="btn-order-empty-create" class="btn btn-ghost whitespace-nowrap">+ Nova Tarefa</button>
+          <button type="button" id="btn-order-empty-create" class="btn btn-ghost whitespace-nowrap w-full md:w-auto">+ Nova Tarefa</button>
         </div>
       </div>
       <div class="modal__body border-t pt-4 space-y-4">

--- a/public/style.css
+++ b/public/style.css
@@ -83,7 +83,7 @@
 @media (max-width:1023px){.chart-grid{grid-template-columns:1fr;}}
 
 /* Tabela de tarefas dentro do modal responsiva */
-.table-responsive{overflow-x:auto;}
+.table-responsive{overflow-x:auto;overflow-y:hidden;width:100%;}
 .table-responsive table{min-width:700px;}
 @media (max-width:480px){.tasks-table td:last-child .btn{width:100%;height:44px;}}
 
@@ -855,6 +855,13 @@ body.has-modal {
     background-color: #f3f4f6;
 }
 
+/* Botões "ghost" com texto devem manter altura de toque padrão */
+.btn.btn-ghost {
+    width: auto;
+    height: var(--input-h);
+    padding: 0 12px;
+}
+
 /* Chip ordem em tarefas */
 /* Progress bar */
 .progress {
@@ -931,7 +938,7 @@ body.has-modal {
 }
 .modal__body {
     overflow: auto;
-    padding: 20px 24px;
+    padding: 16px 24px;
 }
 .modal__title {
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- padroniza gutter vertical e horizontal do modal
- reorganiza cabeçalho de tarefas com contador, barra de progresso e botão responsivo
- garante tabela com colunas mínimas e scroll horizontal somente no contêiner

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dbf879bc8832ebe825af347fee70c