### PR TITLE
Ajustes no layout de tarefas da ordem

### DIFF
--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -157,12 +157,13 @@ function renderTaskList() {
   const frag = document.createDocumentFragment();
   tasks.filter(t => currentFilter === 'all' || t.status === currentFilter).forEach(t => {
     const tr = document.createElement('tr');
+    tr.className = 'h-11';
     const dueText = t.dueDate ? formatDDMMYYYY(t.dueDate) : '-';
     tr.innerHTML = `
-      <td class="min-w-[280px]">${t.title}</td>
-      <td class="text-center min-w-[120px] whitespace-nowrap">${dueText}</td>
-      <td class="text-center min-w-[140px]">${renderTaskStatus(t.status)}</td>
-      <td class="text-right min-w-[160px]"><button type="button" class="btn btn-ghost text-blue-700 whitespace-nowrap" data-action="view-task" data-task-id="${t.id}">Ver detalhes</button></td>`;
+      <td class="px-2 py-2 align-middle min-w-[280px]">${t.title}</td>
+      <td class="px-2 py-2 text-center align-middle min-w-[120px] whitespace-nowrap">${dueText}</td>
+      <td class="px-2 py-2 text-center align-middle min-w-[140px]">${renderTaskStatus(t.status)}</td>
+      <td class="px-2 py-2 text-right align-middle min-w-[160px]"><button type="button" class="btn btn-ghost text-blue-700 whitespace-nowrap" data-action="view-task" data-task-id="${t.id}">Ver detalhes</button></td>`;
     frag.appendChild(tr);
   });
   list.replaceChildren(frag);

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -203,13 +203,13 @@
         <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
       </div>
       </form>
-      <div id="order-tasks" class="mt-6">
-        <div class="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-start md:gap-4 lg:flex-nowrap lg:items-center lg:justify-between">
+      <div id="order-tasks" class="mt-6 px-6">
+        <div class="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-start md:justify-between md:gap-3 lg:flex-nowrap lg:items-center">
           <h3 class="text-base font-semibold md:w-full lg:w-auto">Tarefas desta ordem</h3>
-          <div class="flex flex-col gap-4 md:flex-row md:flex-nowrap md:items-center md:justify-end md:gap-4">
+          <div class="flex flex-col gap-3 md:flex-row md:flex-nowrap md:items-center md:gap-4 md:ml-auto">
             <div class="flex items-center gap-3">
               <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap" aria-live="polite">0/0 abertas</span>
-              <div class="progress" style="--progress-width:160px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite"><div class="progress__bar"></div></div>
+              <div class="progress min-w-[140px]" style="--progress-width:180px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite"><div class="progress__bar"></div></div>
             </div>
             <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap w-full md:w-auto">+ Nova Tarefa</button>
           </div>


### PR DESCRIPTION
## Summary
- Alinha seção "Tarefas desta ordem" ao gutter do modal e reorganiza o cabeçalho com barra de progresso de 180 px
- Ajusta chips e tabela para preservar espaçamentos e rolagem horizontal, com linhas mínimas de 44 px

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dc43cd42c832eb88ffd142daafaeb