### PR TITLE
Refactor order details view with hash navigation

### DIFF
--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -19,12 +19,11 @@ let currentFilter = 'all';
 
 export function initOrderModal() {
   if (window.__orderModalInited) return;
-  overlay = document.getElementById('order-modal-overlay');
+  overlay = document.getElementById('order-view');
   if (!overlay) return;
-  modal = overlay.querySelector('.modal');
+  modal = overlay; // section acts as container
   window.__orderModalInited = true;
-  document.getElementById('btn-order-close')?.addEventListener('click', closeModal);
-  overlay.addEventListener('click', e => { if (e.target === overlay) closeModal(); });
+  document.getElementById('btn-order-back')?.addEventListener('click', () => history.back());
   document.getElementById('btn-order-new-task')?.addEventListener('click', async (e) => {
     if (!currentOrder) return;
     const btn = e.currentTarget;
@@ -61,6 +60,9 @@ export function initOrderModal() {
   document.getElementById('btn-order-empty-create')?.addEventListener('click', () => {
     document.getElementById('btn-order-new-task')?.click();
   });
+  window.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && !overlay.hidden) history.back();
+  });
 }
 
 export async function openOrderModal(orderId) {
@@ -89,7 +91,8 @@ export async function openOrderModal(orderId) {
   document.querySelector('#order-tasks-filters [data-filter="all"]')?.classList.add('filter-active');
   loadTasks(orderId);
   overlay.hidden = false;
-  document.body.classList.add('has-modal');
+  document.getElementById('orders-section')?.classList.add('hidden');
+  document.getElementById('order-modal-title')?.focus();
 }
 
 function loadTasks(orderId) {
@@ -174,7 +177,7 @@ function renderTaskList() {
 
 function closeModal() {
   overlay?.setAttribute('hidden','');
-  document.body.classList.remove('has-modal');
+  document.getElementById('orders-section')?.classList.remove('hidden');
   if (unsubscribeTasks) { unsubscribeTasks(); unsubscribeTasks = null; }
 }
 

--- a/public/js/ui/task-modal.js
+++ b/public/js/ui/task-modal.js
@@ -39,7 +39,7 @@ export function initTaskModal() {
     document.body.classList.remove('has-modal');
     exitEditMode();
     if (returnOrderId) {
-      window.openOrderModal?.(returnOrderId);
+      window.location.hash = `order/${returnOrderId}`;
       returnOrderId = null;
     }
   });

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -36,7 +36,7 @@
       <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
     </header>
 
-    <section class="flex-1 overflow-y-auto py-6">
+    <section id="orders-section" class="flex-1 overflow-y-auto py-6">
       <div class="max-w-[1240px] mx-auto px-4 md:px-6">
         <div class="bg-white rounded-xl shadow-md border border-gray-200 p-5">
           <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between mb-4">
@@ -143,23 +143,18 @@
     </div>
   </div>
 
-  <!-- Modal ordem com comentários -->
-  <div class="modal-overlay" id="order-modal-overlay" hidden>
-    <div class="modal" id="order-modal" data-mode="view" role="dialog" aria-modal="true" aria-labelledby="order-modal-title">
-      <header class="modal__header">
-        <div class="flex items-center gap-2">
-          <h3 id="order-modal-title" class="modal__title">Detalhes da Ordem</h3>
-          <span id="order-status-chip" class="pill"></span>
-          <span id="order-code-chip" class="pill pill--info"></span>
-        </div>
-        <div class="modal__actions">
-          <button id="btn-order-duplicate" class="btn-ghost text-gray-600" title="Duplicar"><i class="fas fa-copy"></i></button>
-          <button id="btn-order-edit" class="btn-ghost text-gray-600" aria-label="Editar"><i class="fas fa-pen"></i></button>
-          <button id="btn-order-close" class="text-gray-600 hover:text-gray-800" aria-label="Fechar"><i class="fas fa-times"></i></button>
-        </div>
-      </header>
-      <form id="order-form" class="modal__body space-y-4 modal-read">
-        <div class="modal__grid-2">
+  <section id="order-view" class="flex-1 overflow-y-auto hidden">
+    <header class="sticky top-0 bg-white border-b flex items-center justify-between p-4 md:px-6">
+      <button id="btn-order-back" class="btn btn-ghost flex items-center gap-2"><i class="fas fa-arrow-left"></i><span>Voltar</span></button>
+      <h3 id="order-modal-title" class="text-lg font-semibold">Detalhes da Ordem</h3>
+      <div class="flex items-center gap-2">
+        <span id="order-code-chip" class="pill pill--info"></span>
+        <span id="order-status-chip" class="pill"></span>
+      </div>
+    </header>
+    <div class="max-w-[1200px] mx-auto px-4 md:px-6 py-6">
+      <form id="order-form" class="space-y-4 modal-read">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="field">
             <label for="order-codigo" class="field__label">Código</label>
             <input id="order-codigo" class="field__input" readonly />
@@ -197,13 +192,13 @@
           <label for="order-obs" class="field__label">Observações</label>
           <textarea id="order-obs" class="field__input" rows="3" readonly></textarea>
         </div>
-      <div class="flex justify-end gap-2 pt-2">
-        <button type="button" id="btn-order-save" class="hidden bg-[#6C9F3D] hover:bg-[#5A8733] text-white px-4 py-2 rounded">Salvar</button>
-        <button type="button" id="btn-order-conclude" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
-        <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
-      </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" id="btn-order-save" class="hidden bg-[#6C9F3D] hover:bg-[#5A8733] text-white px-4 py-2 rounded">Salvar</button>
+          <button type="button" id="btn-order-conclude" class="bg-blue-600 text-white px-4 py-2 rounded">Concluir</button>
+          <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
+        </div>
       </form>
-      <div id="order-tasks" class="mt-6 px-6">
+      <div id="order-tasks" class="mt-6">
         <div class="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-start md:justify-between md:gap-3 lg:flex-nowrap lg:items-center">
           <h3 class="text-base font-semibold md:w-full lg:w-auto">Tarefas desta ordem</h3>
           <div class="flex flex-col gap-3 md:flex-row md:flex-nowrap md:items-center md:gap-4 md:ml-auto">
@@ -238,7 +233,7 @@
           <button type="button" id="btn-order-empty-create" class="btn btn-ghost whitespace-nowrap w-full md:w-auto">+ Nova Tarefa</button>
         </div>
       </div>
-      <div class="modal__body border-t pt-4 space-y-4">
+      <div class="border-t pt-4 space-y-4">
         <div class="flex items-center gap-2">
           <input id="order-comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
           <button id="btn-order-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
@@ -246,7 +241,7 @@
         <div id="order-comments-list" class="space-y-3"></div>
       </div>
     </div>
-  </div>
+  </section>
 
   <script type="module" src="js/ui/sidebar.js"></script>
   <script type="module" src="js/pages/operador-ordens.js"></script>


### PR DESCRIPTION
## Summary
- replace order detail modal with in-page full-screen view
- wire hash-based navigation for order details and return
- ensure task modal closes back to related order

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dca7fb0cc832e900c817202428f4f