### PR TITLE
Fix operador ordens new order button and order view

### DIFF
--- a/public/js/pages/operador-ordens.js
+++ b/public/js/pages/operador-ordens.js
@@ -333,8 +333,8 @@ function openModal(order, mode = 'view') {
     document.getElementById('btn-order-save').classList.remove('hidden');
     document.getElementById('btn-order-conclude').classList.add('hidden');
     document.getElementById('btn-order-cancel').classList.add('hidden');
-    document.getElementById('btn-order-edit').classList.add('hidden');
-    document.getElementById('btn-order-duplicate').classList.add('hidden');
+    document.getElementById('btn-order-edit')?.classList.add('hidden');
+    document.getElementById('btn-order-duplicate')?.classList.add('hidden');
     document.getElementById('order-modal-title').textContent = 'Nova Ordem';
     document.getElementById('order-tasks').classList.add('hidden');
     document.getElementById('order-cliente').focus();
@@ -344,8 +344,8 @@ function openModal(order, mode = 'view') {
     document.getElementById('btn-order-save').classList.add('hidden');
     document.getElementById('btn-order-conclude').classList.remove('hidden');
     document.getElementById('btn-order-cancel').classList.remove('hidden');
-    document.getElementById('btn-order-edit').classList.remove('hidden');
-    document.getElementById('btn-order-duplicate').classList.remove('hidden');
+    document.getElementById('btn-order-edit')?.classList.remove('hidden');
+    document.getElementById('btn-order-duplicate')?.classList.remove('hidden');
     document.getElementById('order-modal-title').textContent = 'Detalhes da Ordem';
     document.getElementById('order-tasks').classList.remove('hidden');
     document.getElementById('order-codigo').focus();

--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -75,7 +75,7 @@ export async function openOrderModal(orderId) {
   if (!overlay) return;
   if (unsubscribeTasks) { unsubscribeTasks(); unsubscribeTasks = null; }
   currentOrder = { id: orderId };
-  const orderRef = doc(db, 'orders', orderId);
+  const orderRef = doc(db, 'ordens', orderId);
   const snap = await getDoc(orderRef);
   if (snap.exists()) {
     const data = snap.data();


### PR DESCRIPTION
## Summary
- prevent missing buttons from breaking order modal
- load operator order details from the correct Firestore collection

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dd00b3ff8832ea79c074c18b04e0b