### PR TITLE
refactor: improve order detail layout

### DIFF
--- a/public/js/pages/operador-ordens.js
+++ b/public/js/pages/operador-ordens.js
@@ -282,7 +282,7 @@ function handleRowAction(e) {
   const order = state.orders.find(o => o.id === id);
   if (!order) return;
   if (action === 'view-order') {
-    window.location.href = `order-details.html?id=${id}`;
+    window.location.href = `order-details.html#order/${id}`;
   } else if (action === 'done') {
     state.current = order;
     updateStatus('Concluída');

--- a/public/js/pages/operador-tarefas.js
+++ b/public/js/pages/operador-tarefas.js
@@ -194,7 +194,7 @@ function renderList(tasks) {
       chip.textContent = `#${code}`;
       chip.title = `Ver ordem #${code}`;
       chip.addEventListener('click', () => {
-        window.location.href = `order-details.html?id=${t.orderId}`;
+        window.location.href = `order-details.html#order/${t.orderId}`;
       });
       tdOrder.appendChild(chip);
     } else {
@@ -241,7 +241,7 @@ export async function openTaskModal(taskId, source = 'table') {
       chip.textContent = `#${code}`;
       chip.title = `Ver ordem #${code}`;
       chip.onclick = () => {
-        window.location.href = `order-details.html?id=${data.orderId}`;
+        window.location.href = `order-details.html#order/${data.orderId}`;
       };
       chip.classList.remove('hidden');
     }

--- a/public/js/pages/order-details.js
+++ b/public/js/pages/order-details.js
@@ -16,6 +16,10 @@ let unsubscribeTasks = null;
 let currentFilter = 'all';
 
 document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') history.back();
+  });
+
   document.getElementById('btn-order-back')?.addEventListener('click', () => history.back());
   document.getElementById('btn-order-new-task')?.addEventListener('click', async e => {
     if (!currentOrder) return;
@@ -54,8 +58,15 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('btn-order-new-task')?.click();
   });
 
-  const params = new URLSearchParams(window.location.search);
-  const id = params.get('id');
+  window.addEventListener('hashchange', () => {
+    const hashId = location.hash.split('/')[1];
+    if (hashId) openOrder(hashId);
+  });
+
+  let id = new URLSearchParams(window.location.search).get('id');
+  if (!id && location.hash.startsWith('#order/')) {
+    id = location.hash.split('/')[1];
+  }
   if (id) openOrder(id);
 });
 
@@ -75,6 +86,7 @@ async function openOrder(orderId) {
     .forEach(ch => ch.classList.remove('filter-active'));
   document.querySelector('#order-tasks-filters [data-filter="all"]')?.classList.add('filter-active');
   loadTasks(orderId);
+  document.getElementById('order-modal-title')?.focus();
 }
 
 function loadTasks(orderId) {

--- a/public/js/ui/task-modal.js
+++ b/public/js/ui/task-modal.js
@@ -85,7 +85,7 @@ export async function openTaskModal(taskId, opts = {}) {
       chip.textContent = `#${ordemCodigo}`;
       chip.title = `Ordem #${ordemCodigo}`;
       chip.onclick = () => {
-        window.location.href = `order-details.html?id=${ordemId}`;
+        window.location.href = `order-details.html#order/${ordemId}`;
       };
       chip.classList.remove('hidden');
     }
@@ -120,7 +120,7 @@ export async function openTaskModal(taskId, opts = {}) {
       chip.textContent = `#${taskOrder.codigo}`;
       chip.title = `Ver ordem #${taskOrder.codigo}`;
       chip.onclick = () => {
-        window.location.href = `order-details.html?id=${taskOrder.id}`;
+        window.location.href = `order-details.html#order/${taskOrder.id}`;
       };
       chip.classList.remove('hidden');
     } else {
@@ -197,7 +197,7 @@ export async function saveTaskEdits() {
       document.getElementById('task-modal').classList.add('hidden');
       document.dispatchEvent(new CustomEvent('task-updated', { detail: { orderId: taskOrder?.id } }));
       if (returnOrderId) {
-        window.location.href = `order-details.html?id=${returnOrderId}`;
+        window.location.href = `order-details.html#order/${returnOrderId}`;
       }
       taskOrder = null;
       returnOrderId = null;
@@ -281,7 +281,7 @@ export async function completeTask() {
   exitEditMode();
   document.dispatchEvent(new CustomEvent('task-updated', { detail: { id: currentTaskId, orderId: taskOrder?.id } }));
   if (returnOrderId) {
-    window.location.href = `order-details.html?id=${returnOrderId}`;
+    window.location.href = `order-details.html#order/${returnOrderId}`;
     returnOrderId = null;
   }
 }

--- a/public/order-details.html
+++ b/public/order-details.html
@@ -56,10 +56,10 @@
     </div>
   </div>
 
-  <section id="order-view" class="flex-1 overflow-y-auto">
-    <header class="sticky top-0 bg-white border-b flex items-center justify-between p-4 md:px-6">
-      <button id="btn-order-back" class="btn btn-ghost flex items-center gap-2"><i class="fas fa-arrow-left"></i><span>Voltar</span></button>
-      <h3 id="order-modal-title" class="text-lg font-semibold">Detalhes da Ordem</h3>
+  <section id="order-view">
+    <header class="sticky top-0 z-10 bg-white border-b flex items-center justify-between p-4 md:px-6">
+      <button id="btn-order-back" class="btn btn-ghost flex items-center gap-2 h-11 px-4"><i class="fas fa-arrow-left"></i><span>Voltar</span></button>
+      <h3 id="order-modal-title" class="text-lg font-semibold" tabindex="-1">Detalhes da Ordem</h3>
       <div class="flex items-center gap-2">
         <span id="order-code-chip" class="pill pill--info"></span>
         <span id="order-status-chip" class="pill"></span>
@@ -111,23 +111,23 @@
           <button type="button" id="btn-order-cancel" class="bg-red-600 text-white px-4 py-2 rounded">Cancelar</button>
         </div>
       </form>
-      <div id="order-tasks" class="mt-6">
-        <div class="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-start md:justify-between md:gap-3 lg:flex-nowrap lg:items-center">
-          <h3 class="text-base font-semibold md:w-full lg:w-auto">Tarefas desta ordem</h3>
-          <div class="flex flex-col gap-3 md:flex-row md:flex-nowrap md:items-center md:gap-4 md:ml-auto">
-            <div class="flex items-center gap-3">
-              <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap" aria-live="polite">0/0 abertas</span>
-              <div class="progress min-w-[140px]" style="--progress-width:180px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite"><div class="progress__bar"></div></div>
+        <div id="order-tasks" class="mt-6">
+          <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <h3 class="text-base font-semibold">Tarefas desta ordem</h3>
+            <div class="flex flex-col gap-4 md:flex-row md:flex-nowrap md:items-center md:gap-4 md:ml-auto">
+              <div class="flex items-center gap-3">
+                <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap" aria-live="polite">0/0 abertas</span>
+                <div class="progress min-w-[160px]" style="--progress-width:180px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite"><div class="progress__bar"></div></div>
+              </div>
+              <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap w-full md:w-auto h-11">+ Nova Tarefa</button>
             </div>
-            <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap w-full md:w-auto">+ Nova Tarefa</button>
           </div>
-        </div>
-        <div id="order-tasks-filters" class="flex flex-wrap gap-2 mt-3">
-          <button type="button" class="chip chip--filter filter-active" data-filter="all">Todas <span class="count">0</span></button>
-          <button type="button" class="chip chip--filter" data-filter="Pendente">Pendentes <span class="count">0</span></button>
-          <button type="button" class="chip chip--filter" data-filter="Atrasada">Atrasadas <span class="count">0</span></button>
-          <button type="button" class="chip chip--filter" data-filter="Concluída">Concluídas <span class="count">0</span></button>
-        </div>
+          <div id="order-tasks-filters" class="flex flex-wrap gap-2 mt-3">
+            <button type="button" class="chip chip--filter filter-active" data-filter="all">Todas <span class="count">0</span></button>
+            <button type="button" class="chip chip--filter" data-filter="Pendente">Pendentes <span class="count">0</span></button>
+            <button type="button" class="chip chip--filter" data-filter="Atrasada">Atrasadas <span class="count">0</span></button>
+            <button type="button" class="chip chip--filter" data-filter="Concluída">Concluídas <span class="count">0</span></button>
+          </div>
         <div id="order-tasks-table" class="table-responsive w-full mt-2">
           <table class="w-full text-sm">
             <thead class="bg-gray-50">
@@ -141,11 +141,11 @@
             <tbody id="order-tasks-list"></tbody>
           </table>
         </div>
-        <div id="order-tasks-empty" class="hidden mt-4 text-sm text-gray-600 flex items-center gap-2">
-          Nenhuma tarefa nesta ordem ainda
-          <button type="button" id="btn-order-empty-create" class="btn btn-ghost whitespace-nowrap w-full md:w-auto">+ Nova Tarefa</button>
+          <div id="order-tasks-empty" class="hidden mt-4 text-sm text-gray-600 flex items-center gap-2">
+            Nenhuma tarefa nesta ordem ainda
+            <button type="button" id="btn-order-empty-create" class="btn btn-ghost whitespace-nowrap w-full md:w-auto h-11">+ Nova Tarefa</button>
+          </div>
         </div>
-      </div>
       <div class="border-t pt-4 space-y-4">
         <div class="flex items-center gap-2">
           <input id="order-comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />


### PR DESCRIPTION
## Summary
- remove internal scroll from order detail page and make header sticky
- refine task section layout and button sizing
- switch order navigation to hash-based URLs with Escape key support

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e0a437fc8832e95a71730e905327e