### PR TITLE
fix: enable detalhes buttons for ordens and tarefas

### DIFF
--- a/public/js/pages/operador-ordens.js
+++ b/public/js/pages/operador-ordens.js
@@ -110,10 +110,10 @@ function render() {
       <td class="px-3 py-3 min-w-[96px] text-right">${o.total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</td>
       <td class="px-3 py-3">
         <div class="flex gap-2">
-          <button class="btn-ghost text-gray-600" title="Ver detalhes" data-action="view-order" data-id="${o.id}"><i class="fas fa-eye"></i></button>
-          <button class="btn-ghost text-gray-600" title="Duplicar" data-action="duplicate" data-id="${o.id}"><i class="fas fa-copy"></i></button>
-          <button class="btn-ghost text-gray-600" title="Encerrar" data-action="done" data-id="${o.id}"><i class="fas fa-flag-checkered"></i></button>
-          <button class="btn-ghost text-gray-600" title="Cancelar" data-action="cancel" data-id="${o.id}"><i class="fas fa-ban"></i></button>
+          <button type="button" class="btn-ghost text-gray-600" title="Ver detalhes" data-action="view-order" data-id="${o.id}"><i class="fas fa-eye"></i></button>
+          <button type="button" class="btn-ghost text-gray-600" title="Duplicar" data-action="duplicate" data-id="${o.id}"><i class="fas fa-copy"></i></button>
+          <button type="button" class="btn-ghost text-gray-600" title="Encerrar" data-action="done" data-id="${o.id}"><i class="fas fa-flag-checkered"></i></button>
+          <button type="button" class="btn-ghost text-gray-600" title="Cancelar" data-action="cancel" data-id="${o.id}"><i class="fas fa-ban"></i></button>
         </div>
       </td>`;
 

--- a/public/js/pages/operador-tarefas.js
+++ b/public/js/pages/operador-tarefas.js
@@ -204,6 +204,7 @@ function renderList(tasks) {
     const tdAction = document.createElement('td');
     tdAction.className = 'px-4 py-2';
     const btn = document.createElement('button');
+    btn.type = 'button';
     btn.className = 'details-btn px-2 py-1 text-sm text-blue-700 border border-blue-700 rounded hover:bg-blue-700 hover:text-white flex items-center gap-1';
     btn.innerHTML = '<i class="fas fa-eye"></i><span>Ver detalhes</span>';
     btn.addEventListener('click', () => openTaskModal(t.id, 'table'));


### PR DESCRIPTION
## Summary
- prevent default form submission by adding `type="button"` to order action buttons
- add explicit `type="button"` to task detail button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2fcee400c832e807d71648ecf6c64