### PR TITLE
Fix "Ver detalhes" buttons

### DIFF
--- a/public/js/pages/operador-dashboard.js
+++ b/public/js/pages/operador-dashboard.js
@@ -49,7 +49,7 @@ if (window.Chart) {
   Chart.register(barValuePlugin);
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
   initTaskDetail();
   const tbl = document.getElementById('dashboard-tasks-table');
   if (tbl && !tbl.__bound) {
@@ -68,7 +68,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   window.addEventListener('hashchange', handleHashChange);
   handleHashChange();
-});
+}
+
+if (document.readyState !== 'loading') {
+  init();
+} else {
+  document.addEventListener('DOMContentLoaded', init);
+}
 
 export async function initOperadorDashboard(userId) {
   await loadFarmId(userId);

--- a/public/js/pages/order-details.js
+++ b/public/js/pages/order-details.js
@@ -8,14 +8,15 @@ import {
   onSnapshot
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 import { parseDateLocal, formatDDMMYYYY, endOfLocalDay } from '../lib/date-utils.js';
-import { openTaskModal } from '../ui/task-modal.js';
+import { initTaskModal, openTaskModal } from '../ui/task-modal.js';
 
 let currentOrder = null;
 let tasks = [];
 let unsubscribeTasks = null;
 let currentFilter = 'all';
 
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
+  initTaskModal();
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape') history.back();
   });
@@ -68,7 +69,13 @@ document.addEventListener('DOMContentLoaded', () => {
     id = location.hash.split('/')[1];
   }
   if (id) openOrder(id);
-});
+}
+
+if (document.readyState !== 'loading') {
+  init();
+} else {
+  document.addEventListener('DOMContentLoaded', init);
+}
 
 async function openOrder(orderId) {
   if (unsubscribeTasks) { unsubscribeTasks(); unsubscribeTasks = null; }

--- a/public/js/ui/order-modal.js
+++ b/public/js/ui/order-modal.js
@@ -8,7 +8,7 @@ import {
   onSnapshot
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 import { parseDateLocal, formatDDMMYYYY, endOfLocalDay } from '../lib/date-utils.js';
-import { openTaskModal } from './task-modal.js';
+import { initTaskModal, openTaskModal } from './task-modal.js';
 
 let overlay;
 let modal;
@@ -18,6 +18,7 @@ let tasks = [];
 let currentFilter = 'all';
 
 export function initOrderModal() {
+  initTaskModal();
   if (window.__orderModalInited) return;
   overlay = document.getElementById('order-view');
   if (!overlay) return;


### PR DESCRIPTION
## Summary
- Initialize task modal on order details screens so task "Ver detalhes" buttons work
- Guard dashboard setup with a direct initializer to ensure task detail links work after load

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3041f9d28832ea1f9fc677b9c9c08