### PR TITLE
feat: add testing utilities and data-test markers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,17 @@
+name: e2e
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,16 @@
 {
+  "scripts": {
+    "test": "TZ=America/Sao_Paulo vitest run --reporter=dot",
+    "test:watch": "TZ=America/Sao_Paulo vitest",
+    "test:e2e": "playwright test"
+  },
   "dependencies": {
     "cors": "^2.8.5",
     "firebase": "^11.10.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.44.0",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.5.2"
   }
 }

--- a/public/js/lib/dashboardUtils.js
+++ b/public/js/lib/dashboardUtils.js
@@ -1,0 +1,53 @@
+import { dedupeTasks } from './taskUtils.js';
+import { mergeOrderTasks } from './orderUtils.js';
+import { classifyStatus } from './taskUtils.js';
+
+export function mergeDashboardTasks({ dashboardTasks = [], orders = [] }) {
+  const orderTasks = mergeOrderTasks(orders);
+  return dedupeTasks([...dashboardTasks, ...orderTasks]);
+}
+
+export function calcKPIs(tasks = [], now = new Date()) {
+  const counts = { concluidas: 0, pendentes: 0, atrasadas: 0, novasMes: 0, concluidasMes: 0 };
+  const tz = 'America/Sao_Paulo';
+  const parts = new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit' }).formatToParts(now);
+  const y = parts.find(p=>p.type==='year').value;
+  const m = parts.find(p=>p.type==='month').value;
+  tasks.forEach(t => {
+    const status = classifyStatus(t, now);
+    if (status === 'Concluída') counts.concluidas++;
+    if (status === 'Pendente') counts.pendentes++;
+    if (status === 'Atrasada') counts.atrasadas++;
+    const due = t.dueISO ? new Date(new Date(t.dueISO).toLocaleString('en-US', { timeZone: tz })) : null;
+    if (due && due.getFullYear() == y && String(due.getMonth()+1).padStart(2,'0') == m) counts.novasMes++;
+    const comp = t.completedAtISO ? new Date(new Date(t.completedAtISO).toLocaleString('en-US',{timeZone:tz})) : null;
+    if (comp && comp.getFullYear()==y && String(comp.getMonth()+1).padStart(2,'0')==m) counts.concluidasMes++;
+  });
+  return counts;
+}
+
+export function buildPieDataset(tasks = [], now = new Date()) {
+  const counts = { Concluída: 0, Pendente: 0, Atrasada: 0 };
+  tasks.forEach(t => counts[classifyStatus(t, now)]++);
+  return {
+    labels: ['Concluídas', 'Pendentes', 'Atrasadas'],
+    data: [counts.Concluída, counts.Pendente, counts.Atrasada]
+  };
+}
+
+export function buildNext7DaysDataset(tasks = [], now = new Date()) {
+  const tz = 'America/Sao_Paulo';
+  const today = new Date(new Date(now).toLocaleString('en-US',{timeZone:tz}));
+  const limit = new Date(today.getTime() + 7*24*3600*1000);
+  const map = new Map();
+  tasks.forEach(t => {
+    if (classifyStatus(t, now) === 'Concluída') return;
+    if (!t.dueISO) return;
+    const due = new Date(new Date(t.dueISO).toLocaleString('en-US',{timeZone:tz}));
+    if (due > limit || due < today) return;
+    const key = `${due.getFullYear()}-${due.getMonth()+1}-${due.getDate()}`;
+    map.set(key, (map.get(key)||0)+1);
+  });
+  const entries = Array.from(map.entries()).sort((a,b)=>new Date(a[0]) - new Date(b[0]));
+  return entries.map(([date,count])=>({date,count}));
+}

--- a/public/js/lib/orderUtils.js
+++ b/public/js/lib/orderUtils.js
@@ -1,0 +1,29 @@
+import { classifyStatus } from './taskUtils.js';
+
+export function mergeOrderTasks(orders = []) {
+  const tasks = [];
+  orders.forEach(order => {
+    const { id: orderId, code: orderCode, tasks: orderTasks = [] } = order || {};
+    orderTasks.forEach((t, idx) => {
+      const id = t.id || `ord:${orderId}:${idx}`;
+      tasks.push({ ...t, id, orderId, orderCode, source: 'ordem' });
+    });
+  });
+  return tasks;
+}
+
+export function calcOrderProgress(tasks = [], now = new Date()) {
+  const total = tasks.length;
+  const open = tasks.filter(t => classifyStatus(t, now) !== 'Concluída').length;
+  const percent = total ? Math.round(((total - open) / total) * 100) : 0;
+  return { percent, open, total };
+}
+
+export function recountByStatus(tasks = [], now = new Date()) {
+  const counts = { Concluída: 0, Pendente: 0, Atrasada: 0 };
+  tasks.forEach(t => {
+    const s = classifyStatus(t, now);
+    counts[s]++;
+  });
+  return counts;
+}

--- a/public/js/lib/router.js
+++ b/public/js/lib/router.js
@@ -1,0 +1,13 @@
+export function handleHashChange(hash, doc = document) {
+  const dash = doc.getElementById('dashboard');
+  const order = doc.getElementById('order-view');
+  const task = doc.getElementById('task-view');
+  [dash, order, task].forEach(el => el && el.classList.add('hidden'));
+  if (hash.startsWith('#order/')) {
+    if (order) order.classList.remove('hidden');
+  } else if (hash.startsWith('#task/')) {
+    if (task) task.classList.remove('hidden');
+  } else {
+    if (dash) dash.classList.remove('hidden');
+  }
+}

--- a/public/js/lib/taskUtils.js
+++ b/public/js/lib/taskUtils.js
@@ -1,0 +1,58 @@
+export function classifyStatus({ dueISO, completedAtISO }, now = new Date()) {
+  if (completedAtISO) return 'Concluída';
+  const tz = 'America/Sao_Paulo';
+  const due = dueISO ? new Date(new Date(dueISO).toLocaleString('en-US', { timeZone: tz })) : null;
+  const todayParts = new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' }).formatToParts(now);
+  const y = todayParts.find(p=>p.type==='year').value;
+  const m = todayParts.find(p=>p.type==='month').value;
+  const d = todayParts.find(p=>p.type==='day').value;
+  const today = new Date(`${y}-${m}-${d}T00:00:00`);
+  if (!due) return 'Pendente';
+  if (due < today) return 'Atrasada';
+  return 'Pendente';
+}
+
+export function formatDateLocal(iso, tz='America/Sao_Paulo') {
+  if (!iso) return '';
+  const d = new Date(new Date(iso).toLocaleString('en-US', { timeZone: tz }));
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth()+1).padStart(2, '0');
+  const yyyy = d.getFullYear();
+  return `${dd}/${mm}/${yyyy}`;
+}
+
+export function normalizeTask(t = {}) {
+  const { id, title, dueISO, completedAtISO, orderId, orderCode, source } = t;
+  return { id, title, dueISO, completedAtISO, orderId, orderCode, source };
+}
+
+export function sortTasks(tasks = [], now = new Date()) {
+  const order = { 'Atrasada': 0, 'Pendente': 1, 'Concluída': 2 };
+  return [...tasks].sort((a, b) => {
+    const sa = order[classifyStatus(a, now)];
+    const sb = order[classifyStatus(b, now)];
+    if (sa !== sb) return sa - sb;
+    const da = a.dueISO ? new Date(a.dueISO).getTime() : 0;
+    const db = b.dueISO ? new Date(b.dueISO).getTime() : 0;
+    return da - db;
+  });
+}
+
+export function dedupeTasks(tasks = []) {
+  const map = new Map();
+  tasks.forEach(t => { if (t && t.id && !map.has(t.id)) map.set(t.id, t); });
+  return Array.from(map.values());
+}
+
+export function antiDuplicate(fn) {
+  let running = false;
+  return async function(...args) {
+    if (running) return;
+    running = true;
+    try {
+      return await fn.apply(this, args);
+    } finally {
+      running = false;
+    }
+  };
+}

--- a/public/js/lib/uiGuards.js
+++ b/public/js/lib/uiGuards.js
@@ -1,0 +1,28 @@
+export function debounce(fn, wait) {
+  let t;
+  return (...args) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...args), wait);
+  };
+}
+
+export function throttle(fn, wait) {
+  let last = 0;
+  return (...args) => {
+    const now = Date.now();
+    if (now - last >= wait) {
+      last = now;
+      fn(...args);
+    }
+  };
+}
+
+export function antiDuplicate(fn) {
+  let running = false;
+  return async function(...args) {
+    if (running) return;
+    running = true;
+    try { return await fn.apply(this, args); }
+    finally { running = false; }
+  };
+}

--- a/public/operador-agenda.html
+++ b/public/operador-agenda.html
@@ -12,12 +12,12 @@
 <body class="min-h-screen bg-gray-100">
   <div id="operador-agenda-marker" class="hidden"></div>
 
-  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false" data-test="btn-hamburguer">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true"></div>
+  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true" data-test="drawer-overlay"></div>
 
-  <aside id="sidebar" class="drawer">
+  <aside id="sidebar" class="drawer" data-test="drawer">
     <div class="sidebar-logo">
       <img src="logo.png" alt="Orgânia" />
     </div>
@@ -34,7 +34,7 @@
   <main class="main-content flex flex-col overflow-hidden">
     <header class="dashboard-header">
       <h1 class="text-lg font-bold text-green-700">Agenda</h1>
-      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
+      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold" data-test="btn-sair"><span>Sair</span></button>
     </header>
 
     <section class="flex-1 overflow-y-auto p-4">
@@ -44,7 +44,7 @@
           <h2 id="monthLabel" class="text-lg font-bold"></h2>
           <button id="nextMonth" class="p-1 rounded hover:bg-gray-200" aria-label="Próximo mês">&gt;</button>
         </div>
-        <table id="calendarTable" class="w-full text-center text-sm"></table>
+        <table id="calendarTable" class="w-full text-center text-sm" data-test="agenda-list"></table>
       </div>
     </section>
   </main>

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -18,12 +18,12 @@
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="operador-dashboard-marker" class="hidden"></div>
 
-  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false" data-test="btn-hamburguer">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true"></div>
+  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true" data-test="drawer-overlay"></div>
 
-  <aside id="sidebar" class="drawer">
+  <aside id="sidebar" class="drawer" data-test="drawer">
     <div class="sidebar-logo">
       <img src="logo.png" alt="Orgânia" />
     </div>
@@ -42,7 +42,7 @@
       <div class="page-container">
         <header class="dashboard-header">
           <h1 class="text-lg font-semibold">Dashboard do Operador</h1>
-          <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
+          <button id="logoutBtn" class="dashboard-btn flex items-center gap-2 text-sm" data-test="btn-sair"><i class="fas fa-sign-out-alt"></i><span>Sair</span></button>
         </header>
 
     <!-- CONTEÚDO PRINCIPAL -->
@@ -55,14 +55,14 @@
             <i class="fas fa-calendar-check text-[20px] text-gray-500"></i>
             <div class="flex flex-col">
               <p class="text-xs text-gray-500">Concluídas mês</p>
-              <p id="monthCompleted" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
+              <p id="monthCompleted" class="kpi-value skeleton text-[28px] font-bold text-gray-800" data-test="kpi-concluidas-mes"></p>
             </div>
           </div>
           <div class="dashboard-card flex items-center gap-3">
             <i class="fas fa-circle-plus text-[20px] text-gray-500"></i>
             <div class="flex flex-col">
               <p class="text-xs text-gray-500">Novas mês</p>
-              <p id="monthNew" class="kpi-value skeleton text-[28px] font-bold text-gray-800"></p>
+              <p id="monthNew" class="kpi-value skeleton text-[28px] font-bold text-gray-800" data-test="kpi-novas-mes"></p>
             </div>
           </div>
         </div>
@@ -71,21 +71,21 @@
             <div class="kpi-icon"><i class="fas fa-circle-check text-[20px] text-gray-500"></i></div>
             <div class="kpi-text">
               <span class="kpi-title">Concluídas</span>
-              <span id="kpi-concluidas" class="kpi-value skeleton text-[#166534]"></span>
+              <span id="kpi-concluidas" class="kpi-value skeleton text-[#166534]" data-test="kpi-concluidas"></span>
             </div>
           </div>
           <div class="kpi-card">
             <div class="kpi-icon"><i class="fas fa-clock text-[20px] text-gray-500"></i></div>
             <div class="kpi-text">
               <span class="kpi-title">Pendentes</span>
-              <span id="kpi-pendentes" class="kpi-value skeleton text-[#92400E]"></span>
+              <span id="kpi-pendentes" class="kpi-value skeleton text-[#92400E]" data-test="kpi-pendentes"></span>
             </div>
           </div>
           <div class="kpi-card">
             <div class="kpi-icon"><i class="fas fa-triangle-exclamation text-[20px] text-gray-500"></i></div>
             <div class="kpi-text">
               <span class="kpi-title">Atrasadas</span>
-              <span id="kpi-atrasadas" class="kpi-value skeleton text-[#991B1B]"></span>
+              <span id="kpi-atrasadas" class="kpi-value skeleton text-[#991B1B]" data-test="kpi-atrasadas"></span>
             </div>
           </div>
         </div>
@@ -97,7 +97,7 @@
       <section class="dashboard-card flex flex-col p-5 min-w-0">
         <h3 class="text-lg font-semibold mb-4">Resumo de Tarefas</h3>
         <div class="flex items-center justify-center w-full h-[260px] sm:h-[300px]">
-          <canvas id="tasksChart" class="w-full h-full"></canvas>
+          <canvas id="tasksChart" class="w-full h-full" data-test="chart-pizza"></canvas>
         </div>
       </section>
 
@@ -111,7 +111,7 @@
           <span>Nada vencendo nos próximos 7 dias</span>
         </div>
         <div id="card-7dias-chart" class="flex items-center justify-center w-full h-[280px] sm:h-[300px] max-w-full">
-          <canvas id="chart-7dias" class="w-full h-full hidden cursor-pointer"></canvas>
+          <canvas id="chart-7dias" class="w-full h-full hidden cursor-pointer" data-test="chart-7dias"></canvas>
         </div>
       </section>
     </section>
@@ -122,10 +122,10 @@
         <div class="flex items-center justify-between mb-4">
           <h3 class="text-lg font-semibold">Tarefas</h3>
           <div class="flex items-center gap-3 flex-wrap justify-end">
-            <input id="searchInput" type="text" placeholder="Buscar..." class="h-11 border border-gray-300 rounded px-3 focus:outline-none" />
+            <input id="searchInput" type="text" placeholder="Buscar..." class="h-11 border border-gray-300 rounded px-3 focus:outline-none" data-test="busca-tarefas" />
             <div class="flex items-center">
               <label for="filterSelect" class="mr-2 text-sm text-gray-700">Status:</label>
-              <select id="filterSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none">
+              <select id="filterSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none" data-test="filtro-status">
                 <option value="todas">Todas</option>
                 <option value="pendentes">Pendentes</option>
                 <option value="concluidas">Concluídas</option>
@@ -134,7 +134,7 @@
             </div>
             <div class="flex items-center">
               <label for="sourceSelect" class="mr-2 text-sm text-gray-700">Origem:</label>
-              <select id="sourceSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none">
+              <select id="sourceSelect" class="h-11 border border-gray-300 rounded px-3 focus:outline-none" data-test="filtro-origem">
                 <option value="todas">Todas</option>
                 <option value="ordem">De Ordens</option>
                 <option value="isoladas">Isoladas</option>
@@ -146,12 +146,12 @@
           </div>
         </div>
         <div class="table-responsive">
-          <table id="dashboard-tasks-table" class="tasks-table w-full table-auto text-left text-sm">
+          <table id="dashboard-tasks-table" class="tasks-table w-full table-auto text-left text-sm" data-test="tbl-dashboard-tarefas">
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Título</th>
                 <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700 min-w-[72px]">Talhão</th>
-                <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700 min-w-[96px] hidden sm:table-cell">Ordem</th>
+                <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700 min-w-[96px] hidden sm:table-cell" data-test="col-ordem">Ordem</th>
                 <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700 min-w-[112px]">Data</th>
                 <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700 min-w-[120px]">Status</th>
                 <th scope="col" class="px-3 h-11 text-xs font-semibold text-gray-700">Ações</th>

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -12,12 +12,12 @@
 <body class="min-h-screen bg-[#F9FAFB]">
   <div id="operador-ordens-marker" class="hidden"></div>
 
-  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false" data-test="btn-hamburguer">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true"></div>
+  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true" data-test="drawer-overlay"></div>
 
-  <aside id="sidebar" class="drawer">
+  <aside id="sidebar" class="drawer" data-test="drawer">
     <div class="sidebar-logo">
       <img src="logo.png" alt="Orgânia" />
     </div>
@@ -33,7 +33,7 @@
   <main class="main-content flex flex-col overflow-hidden">
     <header class="dashboard-header">
       <h1 class="text-lg font-bold text-green-700">Ordens</h1>
-      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
+      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold" data-test="btn-sair"><span>Sair</span></button>
     </header>
 
     <section id="orders-section" class="flex-1 overflow-y-auto py-6">
@@ -77,7 +77,7 @@
             </div>
           </div>
           <div class="overflow-x-auto">
-            <table class="w-full table-auto">
+            <table class="w-full table-auto" data-test="tbl-ordens">
               <thead class="bg-gray-50">
                 <tr class="text-left text-[13px] font-semibold text-gray-700 h-10">
                   <th scope="col" class="px-3">Código</th>
@@ -139,7 +139,7 @@
     </div>
   </section>
 
-  <section id="order-view" class="flex-1 overflow-y-auto hidden">
+  <section id="order-view" class="flex-1 overflow-y-auto hidden" data-test="order-view">
     <header class="sticky top-0 bg-white border-b flex items-center justify-between p-4 md:px-6">
       <button id="btn-order-back" class="btn btn-ghost flex items-center gap-2"><i class="fas fa-arrow-left"></i><span>Voltar</span></button>
       <h3 id="order-modal-title" class="text-lg font-semibold">Detalhes da Ordem</h3>
@@ -199,20 +199,20 @@
           <h3 class="text-base font-semibold md:w-full lg:w-auto">Tarefas desta ordem</h3>
           <div class="flex flex-col gap-3 md:flex-row md:flex-nowrap md:items-center md:gap-4 md:ml-auto">
             <div class="flex items-center gap-3">
-              <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap" aria-live="polite">0/0 abertas</span>
-              <div class="progress min-w-[140px]" style="--progress-width:180px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite"><div class="progress__bar"></div></div>
+              <span id="order-tasks-counter" class="text-sm text-gray-600 whitespace-nowrap" aria-live="polite" data-test="ordem-counter">0/0 abertas</span>
+              <div class="progress min-w-[140px]" style="--progress-width:180px" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progresso de tarefas" aria-live="polite" data-test="ordem-progress"><div class="progress__bar"></div></div>
             </div>
-            <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap w-full md:w-auto">+ Nova Tarefa</button>
+            <button id="btn-order-new-task" type="button" class="btn btn-ghost whitespace-nowrap w-full md:w-auto" data-test="btn-ordem-nova-tarefa">+ Nova Tarefa</button>
           </div>
         </div>
         <div id="order-tasks-filters" class="flex flex-wrap gap-2 mt-3">
-          <button type="button" class="chip chip--filter filter-active" data-filter="all">Todas <span class="count">0</span></button>
-          <button type="button" class="chip chip--filter" data-filter="Pendente">Pendentes <span class="count">0</span></button>
-          <button type="button" class="chip chip--filter" data-filter="Atrasada">Atrasadas <span class="count">0</span></button>
-          <button type="button" class="chip chip--filter" data-filter="Concluída">Concluídas <span class="count">0</span></button>
+          <button type="button" class="chip chip--filter filter-active" data-filter="all" data-test="chip-filtro-tarefas">Todas <span class="count">0</span></button>
+          <button type="button" class="chip chip--filter" data-filter="Pendente" data-test="chip-filtro-tarefas">Pendentes <span class="count">0</span></button>
+          <button type="button" class="chip chip--filter" data-filter="Atrasada" data-test="chip-filtro-tarefas">Atrasadas <span class="count">0</span></button>
+          <button type="button" class="chip chip--filter" data-filter="Concluída" data-test="chip-filtro-tarefas">Concluídas <span class="count">0</span></button>
         </div>
         <div id="order-tasks-table" class="table-responsive w-full mt-2">
-          <table class="w-full text-sm">
+          <table class="w-full text-sm" data-test="tbl-ordem-tarefas">
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="px-2 py-2 text-left min-w-[280px]">Título</th>

--- a/public/operador-perfil.html
+++ b/public/operador-perfil.html
@@ -12,12 +12,12 @@
 <body class="min-h-screen bg-gray-100">
   <div id="operador-perfil-marker" class="hidden"></div>
 
-  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false" data-test="btn-hamburguer">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true"></div>
+  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true" data-test="drawer-overlay"></div>
 
-  <aside id="sidebar" class="drawer">
+  <aside id="sidebar" class="drawer" data-test="drawer">
     <div class="sidebar-logo">
       <img src="logo.png" alt="Orgânia" />
     </div>
@@ -34,7 +34,7 @@
   <main class="main-content flex flex-col overflow-hidden">
     <header class="dashboard-header">
       <h1 class="text-lg font-bold text-green-700">Perfil</h1>
-      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
+      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold" data-test="btn-sair"><span>Sair</span></button>
     </header>
 
     <section class="flex-1 overflow-y-auto p-4">

--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -12,12 +12,12 @@
 <body class="min-h-screen bg-gray-100">
   <div id="operador-tarefas-marker" class="hidden"></div>
 
-  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false">
+  <button id="btn-sidebar-toggle" class="sidebar-toggle" aria-controls="sidebar" aria-expanded="false" data-test="btn-hamburguer">
     <i class="fas fa-bars"></i>
   </button>
-  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true"></div>
+  <div id="sidebar-backdrop" class="drawer-overlay" aria-hidden="true" data-test="drawer-overlay"></div>
 
-  <aside id="sidebar" class="drawer">
+  <aside id="sidebar" class="drawer" data-test="drawer">
     <div class="sidebar-logo">
       <img src="logo.png" alt="Orgânia" />
     </div>
@@ -34,7 +34,7 @@
   <main class="main-content flex flex-col overflow-hidden">
     <header class="dashboard-header">
       <h1 class="text-lg font-bold text-green-700">Tarefas</h1>
-      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold"><span>Sair</span></button>
+      <button id="logoutBtn" onclick="logout()" class="dashboard-btn text-red-600 font-semibold" data-test="btn-sair"><span>Sair</span></button>
     </header>
 
     <section class="flex-1 overflow-y-auto p-4">
@@ -42,7 +42,7 @@
         <h2 class="text-lg font-bold mb-4">Minhas Tarefas</h2>
         <div id="activeFilters" class="mb-4 hidden"></div>
         <div class="overflow-x-auto">
-          <table class="min-w-full divide-y divide-gray-200">
+          <table class="min-w-full divide-y divide-gray-200" data-test="tbl-tarefas">
             <thead class="bg-gray-50">
               <tr>
                 <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Talhão</th>
@@ -73,7 +73,7 @@
           <button id="btn-close" class="text-gray-600 hover:text-gray-800" aria-label="Fechar"><i class="fas fa-times"></i></button>
         </div>
       </header>
-      <form id="task-form" class="modal__body space-y-4 modal-read">
+      <form id="task-form" class="modal__body space-y-4 modal-read" data-test="form-tarefa">
         <div class="field">
           <label class="field__label" for="task-titulo">Título</label>
           <input id="task-titulo" class="field__input" disabled />
@@ -97,10 +97,10 @@
       </form>
       <div class="modal__body border-t space-y-4">
         <div class="flex items-center gap-2">
-          <input id="comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." />
-          <button id="btn-add-comment" class="text-green-700"><i class="fas fa-paper-plane"></i></button>
+          <input id="comment-input" class="flex-1 border rounded p-2" placeholder="Adicionar comentário..." data-test="input-comentario" />
+          <button id="btn-add-comment" class="text-green-700" data-test="btn-comentar"><i class="fas fa-paper-plane"></i></button>
         </div>
-        <div id="comments-list" class="space-y-3"></div>
+        <div id="comments-list" class="space-y-3" data-test="list-comentarios"></div>
       </div>
     </div>
   </div>

--- a/tests/e2e/sample.spec.ts
+++ b/tests/e2e/sample.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('sample', async ({ page }) => {
+  await page.goto('about:blank');
+  expect(1).toBe(1);
+});

--- a/tests/fixtures/seed.json
+++ b/tests/fixtures/seed.json
@@ -1,0 +1,17 @@
+{
+  "orders": [
+    {
+      "id": "1",
+      "code": "ORD-001",
+      "tasks": [
+        {"id":"t1","title":"Tarefa Pendente","dueISO":"2024-05-20","completedAtISO":null},
+        {"id":"t2","title":"Tarefa Atrasada","dueISO":"2024-05-10","completedAtISO":null},
+        {"id":"t3","title":"Tarefa Concluída","dueISO":"2024-05-05","completedAtISO":"2024-05-04"}
+      ]
+    }
+  ],
+  "tasks": [
+    {"id":"t4","title":"Isolada 1","dueISO":"2024-05-15","completedAtISO":null},
+    {"id":"t5","title":"Isolada 2","dueISO":"2024-05-18","completedAtISO":"2024-05-17"}
+  ]
+}

--- a/tests/integration/dom-dashboard.spec.ts
+++ b/tests/integration/dom-dashboard.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { loadDOM } from '../utils/dom.js';
+import { selectors } from '../utils/selectors.ts';
+
+describe('dashboard DOM', () => {
+  const dom = loadDOM('public/operador-dashboard.html');
+  it('contains dashboard table', () => {
+    const el = dom.window.document.querySelector(selectors.tblDashboardTarefas);
+    expect(el).not.toBeNull();
+  });
+});

--- a/tests/unit/dashboardUtils.spec.ts
+++ b/tests/unit/dashboardUtils.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { mergeDashboardTasks, calcKPIs, buildPieDataset, buildNext7DaysDataset } from '../../public/js/lib/dashboardUtils.js';
+
+const now = new Date('2024-05-15T12:00:00-03:00');
+
+const dashboardTasks = [ {id:'x', dueISO:'2024-05-20'} ];
+const orders = [ {id:'1', code:'ORD-001', tasks:[{id:'y', dueISO:'2024-05-10'}]} ];
+
+describe('mergeDashboardTasks', () => {
+  it('merges dashboard and order tasks', () => {
+    const tasks = mergeDashboardTasks({ dashboardTasks, orders });
+    expect(tasks).toHaveLength(2);
+  });
+});
+
+describe('calcKPIs', () => {
+  it('calculates counts', () => {
+    const tasks = mergeDashboardTasks({ dashboardTasks, orders });
+    const kpi = calcKPIs(tasks, now);
+    expect(kpi.pendentes).toBe(2);
+  });
+});
+
+describe('buildPieDataset', () => {
+  it('returns dataset', () => {
+    const tasks = mergeDashboardTasks({ dashboardTasks, orders });
+    const pie = buildPieDataset(tasks, now);
+    expect(pie.data.reduce((a,b)=>a+b,0)).toBe(2);
+  });
+});
+
+describe('buildNext7DaysDataset', () => {
+  it('filters next seven days', () => {
+    const tasks = mergeDashboardTasks({ dashboardTasks, orders });
+    const ds = buildNext7DaysDataset(tasks, now);
+    expect(Array.isArray(ds)).toBe(true);
+  });
+});

--- a/tests/unit/orderUtils.spec.ts
+++ b/tests/unit/orderUtils.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { mergeOrderTasks, calcOrderProgress, recountByStatus } from '../../public/js/lib/orderUtils.js';
+
+const orders = [
+  { id:'1', code:'ORD-001', tasks:[
+    { id:'a', dueISO:'2024-05-15' },
+    { id:'b', completedAtISO:'2024-05-10' }
+  ]}
+];
+
+const now = new Date('2024-05-15T12:00:00-03:00');
+
+describe('mergeOrderTasks', () => {
+  it('flattens tasks with order info', () => {
+    const res = mergeOrderTasks(orders);
+    expect(res[0]).toMatchObject({ orderId:'1', orderCode:'ORD-001', source:'ordem' });
+  });
+});
+
+describe('calcOrderProgress', () => {
+  it('computes percentages', () => {
+    const tasks = mergeOrderTasks(orders);
+    const prog = calcOrderProgress(tasks, now);
+    expect(prog).toEqual({ percent:50, open:1, total:2 });
+  });
+});
+
+describe('recountByStatus', () => {
+  it('counts statuses', () => {
+    const tasks = mergeOrderTasks(orders);
+    const counts = recountByStatus(tasks, now);
+    expect(counts).toEqual({ Concluída:1, Pendente:1, Atrasada:0 });
+  });
+});

--- a/tests/unit/taskUtils.spec.ts
+++ b/tests/unit/taskUtils.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { classifyStatus, formatDateLocal, sortTasks, dedupeTasks } from '../../public/js/lib/taskUtils.js';
+
+const now = new Date('2024-05-15T12:00:00-03:00');
+
+describe('classifyStatus', () => {
+  it('classifies today as Pendente', () => {
+    expect(classifyStatus({ dueISO: '2024-05-15' }, now)).toBe('Pendente');
+  });
+  it('classifies past as Atrasada', () => {
+    expect(classifyStatus({ dueISO: '2024-05-10' }, now)).toBe('Atrasada');
+  });
+  it('classifies completed as Concluída', () => {
+    expect(classifyStatus({ completedAtISO: '2024-05-14' }, now)).toBe('Concluída');
+  });
+});
+
+describe('formatDateLocal', () => {
+  it('formats ISO to dd/MM/yyyy', () => {
+    expect(formatDateLocal('2024-05-05T00:00:00Z')).toBe('04/05/2024');
+  });
+});
+
+describe('sortTasks', () => {
+  it('sorts by status and due date', () => {
+    const tasks = [
+      { id: '1', dueISO: '2024-05-16' },
+      { id: '2', dueISO: '2024-05-10' },
+      { id: '3', completedAtISO: '2024-05-10' }
+    ];
+    const sorted = sortTasks(tasks, now).map(t => t.id);
+    expect(sorted).toEqual(['2', '1', '3']);
+  });
+});
+
+describe('dedupeTasks', () => {
+  it('removes duplicates by id', () => {
+    const tasks = [{id:'1'},{id:'1'},{id:'2'}];
+    expect(dedupeTasks(tasks)).toHaveLength(2);
+  });
+});

--- a/tests/utils/dom.ts
+++ b/tests/utils/dom.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { JSDOM } from 'jsdom';
+
+export function loadDOM(path) {
+  const html = readFileSync(path, 'utf8');
+  return new JSDOM(html, { url: 'http://localhost', pretendToBeVisual: true });
+}
+
+export function setTimezone() {
+  process.env.TZ = 'America/Sao_Paulo';
+}

--- a/tests/utils/selectors.ts
+++ b/tests/utils/selectors.ts
@@ -1,0 +1,7 @@
+export const selectors = {
+  tblDashboardTarefas: '[data-test="tbl-dashboard-tarefas"]',
+  tblTarefas: '[data-test="tbl-tarefas"]',
+  tblOrdens: '[data-test="tbl-ordens"]',
+  drawer: '[data-test="drawer"]',
+  btnHamburguer: '[data-test="btn-hamburguer"]'
+};


### PR DESCRIPTION
## Summary
- configure vitest and playwright scripts
- extract reusable task/order/dashboard utilities
- add initial data-test attributes across operador pages

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30840e9b8832eafcf3c5252034677