### PR TITLE
Add router and data mapping tests

### DIFF
--- a/tests/e2e/router.spec.ts
+++ b/tests/e2e/router.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const routerPath = path.resolve('public/js/lib/router.js');
+
+function toFileUrl(p) {
+  const pathName = p.replace(/\\/g, '/');
+  return 'file://' + pathName;
+}
+
+test('router toggles sections', async ({ page }) => {
+  const url = toFileUrl(routerPath);
+  await page.setContent(`
+    <div id="dashboard"></div>
+    <div id="order-view" class="hidden"></div>
+    <div id="task-view" class="hidden"></div>
+    <script type="module">
+      import { handleHashChange } from '${url}';
+      window.handleHashChange = handleHashChange;
+    </script>
+  `);
+  await page.evaluate(() => window.handleHashChange('#task/1'));
+  const taskHidden = await page.$eval('#task-view', el => el.classList.contains('hidden'));
+  const dashHidden = await page.$eval('#dashboard', el => el.classList.contains('hidden'));
+  expect(taskHidden).toBe(false);
+  expect(dashHidden).toBe(true);
+});

--- a/tests/integration/data-mapping.spec.ts
+++ b/tests/integration/data-mapping.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { mergeDashboardTasks, calcKPIs } from '../../public/js/lib/dashboardUtils.js';
+import { mergeOrderTasks } from '../../public/js/lib/orderUtils.js';
+import { classifyStatus } from '../../public/js/lib/taskUtils.js';
+import { setTimezone } from '../utils/dom.js';
+
+describe('data mapping from seed', () => {
+  setTimezone();
+  const seed = JSON.parse(readFileSync('tests/fixtures/seed.json','utf8'));
+  const now = new Date('2024-05-15T12:00:00-03:00');
+
+  it('flattens order tasks with order info', () => {
+    const tasks = mergeOrderTasks(seed.orders);
+    expect(tasks).toHaveLength(3);
+    expect(tasks[0]).toHaveProperty('orderCode');
+  });
+
+  it('merges dashboard and order tasks', () => {
+    const tasks = mergeDashboardTasks({ dashboardTasks: seed.tasks, orders: seed.orders });
+    expect(tasks).toHaveLength(5);
+    const statuses = tasks.map(t => classifyStatus(t, now));
+    expect(statuses.filter(s=>s==='Concluída')).toHaveLength(2);
+    expect(statuses.filter(s=>s==='Pendente')).toHaveLength(2);
+    expect(statuses.filter(s=>s==='Atrasada')).toHaveLength(1);
+  });
+
+  it('computes KPI counts', () => {
+    const tasks = mergeDashboardTasks({ dashboardTasks: seed.tasks, orders: seed.orders });
+    const kpi = calcKPIs(tasks, now);
+    expect(kpi).toEqual({ concluidas:2, pendentes:2, atrasadas:1, novasMes:5, concluidasMes:2 });
+  });
+});

--- a/tests/integration/router.spec.ts
+++ b/tests/integration/router.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { handleHashChange } from '../../public/js/lib/router.js';
+
+function makeDOM() {
+  const dom = new JSDOM(`
+    <div id="dashboard"></div>
+    <div id="order-view" class="hidden"></div>
+    <div id="task-view" class="hidden"></div>
+  `);
+  return dom;
+}
+
+describe('handleHashChange', () => {
+  it('shows order view for #order/', () => {
+    const dom = makeDOM();
+    handleHashChange('#order/1', dom.window.document);
+    const order = dom.window.document.getElementById('order-view');
+    const dash = dom.window.document.getElementById('dashboard');
+    expect(order.classList.contains('hidden')).toBe(false);
+    expect(dash.classList.contains('hidden')).toBe(true);
+  });
+
+  it('shows task view for #task/', () => {
+    const dom = makeDOM();
+    handleHashChange('#task/99', dom.window.document);
+    const task = dom.window.document.getElementById('task-view');
+    const dash = dom.window.document.getElementById('dashboard');
+    expect(task.classList.contains('hidden')).toBe(false);
+    expect(dash.classList.contains('hidden')).toBe(true);
+  });
+
+  it('defaults to dashboard for other hashes', () => {
+    const dom = makeDOM();
+    handleHashChange('#unknown', dom.window.document);
+    const dash = dom.window.document.getElementById('dashboard');
+    expect(dash.classList.contains('hidden')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit-style integration test for router hash handling
- add seed-based data mapping integration test with KPI checks
- add Playwright e2e test to exercise router section toggling

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden for lru-cache)*
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30d5a5038832eb4123b0015ddd586