### PR TITLE
feat: expand agronomo dashboard

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -38,16 +38,101 @@
           <h1 class="text-xl font-bold">Painel do Agrônomo</h1>
         </div>
         <div class="flex space-x-2">
-          <button id="addClientBtn" class="dashboard-btn flex items-center text-sm"><i class="fas fa-user-plus mr-2"></i>Adicionar Cliente</button>
+          <button id="btn-novo-lead" class="dashboard-btn flex items-center text-sm"><i class="fas fa-user-plus mr-2"></i>+ Novo Lead</button>
+          <button id="btn-iniciar-visita" class="dashboard-btn flex items-center text-sm"><i class="fas fa-walking mr-2"></i>Iniciar Visita</button>
           <button onclick="logout()" class="dashboard-btn flex items-center text-sm"><i class="fas fa-sign-out-alt mr-2"></i>Sair</button>
         </div>
       </div>
     </header>
+    <div id="offline-indicator" class="fixed top-0 right-0 m-2 bg-yellow-200 text-yellow-800 text-xs px-2 py-1 rounded hidden">Offline</div>
 
     <div class="dashboard-container py-6">
-      <section class="dashboard-section">
-        <h2 class="text-lg font-semibold">Clientes</h2>
+      <nav class="flex space-x-4 overflow-x-auto mb-6" role="tablist">
+        <button class="tab-btn active" data-tab="leads">Leads</button>
+        <button class="tab-btn" data-tab="mapa">Mapa</button>
+        <button class="tab-btn" data-tab="agenda">Agenda</button>
+        <button class="tab-btn" data-tab="propostas">Propostas</button>
+        <button class="tab-btn" data-tab="clientes">Clientes</button>
+        <button class="tab-btn" data-tab="comentarios">Comentários</button>
+      </nav>
+
+      <section id="tab-leads" class="tab-panel">
+        <div class="flex flex-wrap gap-2 mb-4">
+          <input id="lead-busca" type="text" placeholder="Buscar" class="flex-1 min-w-[150px] border p-2 rounded" />
+          <select id="lead-filtro-estagio" class="border p-2 rounded">
+            <option value="">Estágio</option>
+          </select>
+          <select id="lead-filtro-cultura" class="border p-2 rounded">
+            <option value="">Cultura</option>
+          </select>
+          <select id="lead-filtro-periodo" class="border p-2 rounded">
+            <option value="7">7 dias</option>
+            <option value="30">30 dias</option>
+            <option value="90">90 dias</option>
+          </select>
+        </div>
+        <div id="lead-lista" class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead class="sr-only md:not-sr-only">
+              <tr>
+                <th class="text-left p-2">Nome/Propriedade</th>
+                <th class="text-left p-2">Município/UF</th>
+                <th class="text-left p-2">Culturas</th>
+                <th class="text-left p-2">Estágio</th>
+                <th class="text-left p-2">Última visita</th>
+                <th class="text-left p-2">Próximo passo</th>
+                <th class="text-left p-2">Ações</th>
+              </tr>
+            </thead>
+            <tbody id="lead-list"></tbody>
+          </table>
+        </div>
+        <div id="lead-funil" class="mt-6 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4"></div>
+      </section>
+
+      <section id="tab-mapa" class="tab-panel hidden">
+        <div id="mapa-container" class="h-64 bg-white rounded shadow mb-4"></div>
+        <ul id="mapa-lista" class="space-y-2"></ul>
+      </section>
+
+      <section id="tab-agenda" class="tab-panel hidden">
+        <div class="flex gap-2 mb-4">
+          <select id="agenda-filtro-periodo" class="border p-2 rounded">
+            <option value="7">7 dias</option>
+            <option value="30">30 dias</option>
+          </select>
+        </div>
+        <ul id="agenda-lista" class="space-y-2"></ul>
+      </section>
+
+      <section id="tab-propostas" class="tab-panel hidden">
+        <div class="overflow-x-auto">
+          <table id="tbl-propostas" class="min-w-full text-sm">
+            <thead class="sr-only md:not-sr-only">
+              <tr>
+                <th class="p-2 text-left">Lead</th>
+                <th class="p-2 text-left">Total</th>
+                <th class="p-2 text-left">Status</th>
+                <th class="p-2 text-left">Validade</th>
+                <th class="p-2 text-left">Ações</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div id="modal-proposta" class="hidden"></div>
+      </section>
+
+      <section id="tab-clientes" class="tab-panel hidden">
         <div id="clientList" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"></div>
+      </section>
+
+      <section id="tab-comentarios" class="tab-panel hidden">
+        <ul id="list-comentarios" class="space-y-2 mb-4"></ul>
+        <div class="flex gap-2">
+          <input id="input-comentario" class="flex-1 border p-2 rounded" placeholder="Adicionar comentário" />
+          <button id="btn-comentar" class="px-4 py-2 bg-green-600 text-white rounded">Enviar</button>
+        </div>
       </section>
     </div>
 
@@ -56,11 +141,39 @@
     </footer>
   </main>
 
+  <div id="modal-novo-lead" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
+    <div class="bg-white p-4 rounded w-full max-w-md max-h-full overflow-y-auto">
+      <h2 class="text-lg font-semibold mb-4">Novo Lead</h2>
+      <form id="form-novo-lead" class="space-y-2">
+        <input id="lead-nomeContato" required class="w-full border p-2 rounded" placeholder="Nome do contato" />
+        <input id="lead-propriedade" class="w-full border p-2 rounded" placeholder="Propriedade" />
+        <div class="flex gap-2">
+          <input id="lead-municipio" required class="flex-1 border p-2 rounded" placeholder="Município" />
+          <input id="lead-uf" required maxlength="2" class="w-20 border p-2 rounded" placeholder="UF" />
+        </div>
+        <input id="lead-telefone" class="w-full border p-2 rounded" placeholder="Telefone" />
+        <input id="lead-email" class="w-full border p-2 rounded" placeholder="Email" />
+        <input id="lead-culturas" class="w-full border p-2 rounded" placeholder="Culturas (separadas por vírgula)" />
+        <input id="lead-areaHa" type="number" class="w-full border p-2 rounded" placeholder="Área (ha)" />
+        <input id="lead-origem" class="w-full border p-2 rounded" placeholder="Origem" />
+        <textarea id="lead-notas" class="w-full border p-2 rounded" placeholder="Notas"></textarea>
+        <div class="flex items-center justify-between">
+          <button id="btn-lead-geo" type="button" class="text-sm text-green-700 underline">Usar localização atual</button>
+          <div class="space-x-2">
+            <button type="button" id="btn-cancel-lead" class="px-4 py-2 border rounded">Cancelar</button>
+            <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">Salvar</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <script src="/__/firebase/9.6.1/firebase-app-compat.js"></script>
   <script src="/__/firebase/9.6.1/firebase-auth-compat.js"></script>
   <script src="/__/firebase/9.6.1/firebase-firestore-compat.js"></script>
   <script src="/__/firebase/init.js"></script>
   <script type="module" src="js/services/auth.js"></script>
   <script type="module" src="js/ui/sidebar.js"></script>
+  <script type="module" src="js/pages/dashboard-agronomo.js"></script>
 </body>
 </html>

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -1,31 +1,271 @@
 // js/pages/dashboard-agronomo.js
-import { db } from '../config/firebase.js';
-import { collection, getDocs, query, where } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+// Dashboard do agrônomo com suporte a leads, clientes e uso offline
 
-export async function initAgronomoDashboard(userId) {
-  const clientList = document.getElementById('clientList');
-  const addBtn = document.getElementById('addClientBtn');
-  if (!addBtn) {
-    return;
+// Wrapper simples para IndexedDB com fallback em localStorage
+const crmStore = (() => {
+  const DB_NAME = 'crm';
+  const DB_VERSION = 1;
+  const STORES = ['leads', 'visitas', 'propostas', 'clientes'];
+  let db;
+  let useLocal = false;
+
+  function openDB() {
+    if (db || useLocal) return Promise.resolve(db);
+    return new Promise((resolve) => {
+      try {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = (e) => {
+          const d = e.target.result;
+          STORES.forEach((name) => {
+            if (!d.objectStoreNames.contains(name)) {
+              d.createObjectStore(name, { keyPath: 'id' });
+            }
+          });
+        };
+        req.onsuccess = () => {
+          db = req.result;
+          resolve(db);
+        };
+        req.onerror = () => {
+          useLocal = true;
+          resolve(null);
+        };
+      } catch (err) {
+        useLocal = true;
+        resolve(null);
+      }
+    });
   }
-  addBtn.addEventListener('click', () => {
-    window.location.href = 'client-details.html';
-  });
 
-  try {
-    const q = query(collection(db, 'clients'), where('agronomistId', '==', userId));
-    const clientsSnap = await getDocs(q);
-    clientsSnap.forEach(clientDoc => {
-      const clientData = clientDoc.data();
+  function lsKey(col) {
+    return `crm:${col}`;
+  }
+  function lsRead(col) {
+    return JSON.parse(localStorage.getItem(lsKey(col)) || '[]');
+  }
+  function lsWrite(col, data) {
+    localStorage.setItem(lsKey(col), JSON.stringify(data));
+  }
+
+  async function getAll(col) {
+    if (useLocal) return lsRead(col);
+    const d = await openDB();
+    if (!d) return lsRead(col);
+    return new Promise((res) => {
+      const tx = d.transaction(col, 'readonly');
+      const store = tx.objectStore(col);
+      const req = store.getAll();
+      req.onsuccess = () => res(req.result || []);
+      req.onerror = () => res([]);
+    });
+  }
+
+  async function getById(col, id) {
+    if (useLocal) return lsRead(col).find((r) => r.id === id);
+    const d = await openDB();
+    if (!d) return lsRead(col).find((r) => r.id === id);
+    return new Promise((res) => {
+      const tx = d.transaction(col, 'readonly');
+      const req = tx.objectStore(col).get(id);
+      req.onsuccess = () => res(req.result);
+      req.onerror = () => res(undefined);
+    });
+  }
+
+  async function put(col, data) {
+    if (useLocal) {
+      const arr = lsRead(col);
+      const idx = arr.findIndex((r) => r.id === data.id);
+      if (idx >= 0) arr[idx] = data; else arr.push(data);
+      lsWrite(col, arr);
+      return;
+    }
+    const d = await openDB();
+    if (!d) return put(col, data);
+    return new Promise((res) => {
+      const tx = d.transaction(col, 'readwrite');
+      tx.objectStore(col).put(data);
+      tx.oncomplete = () => res();
+      tx.onerror = () => res();
+    });
+  }
+
+  async function insert(col, data) { return put(col, data); }
+  async function update(col, data) { return put(col, data); }
+  async function upsert(col, data) { return put(col, data); }
+
+  return { getAll, getById, insert, update, upsert };
+})();
+
+let currentUserId = null;
+
+function setupTabs() {
+  const buttons = document.querySelectorAll('.tab-btn');
+  const panels = document.querySelectorAll('.tab-panel');
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      buttons.forEach((b) => b.classList.remove('active'));
+      panels.forEach((p) => p.classList.add('hidden'));
+      btn.classList.add('active');
+      const panel = document.getElementById(`tab-${btn.dataset.tab}`);
+      if (panel) panel.classList.remove('hidden');
+    });
+  });
+}
+
+function setupOfflineIndicator() {
+  const el = document.getElementById('offline-indicator');
+  function update() {
+    el.classList.toggle('hidden', navigator.onLine);
+  }
+  window.addEventListener('online', () => { update(); syncPending(); });
+  window.addEventListener('offline', update);
+  update();
+}
+
+async function syncPending() {
+  if (!navigator.onLine) return;
+  const fs = firebase.firestore();
+  const leads = await crmStore.getAll('leads');
+  for (const l of leads.filter((x) => x.syncFlag === 'local-only')) {
+    try {
+      await fs.collection('leads').doc(l.id).set({ ...l, syncFlag: 'synced' });
+      l.syncFlag = 'synced';
+      await crmStore.upsert('leads', l);
+    } catch (err) {
+      console.warn('Falha ao sincronizar lead', err);
+    }
+  }
+}
+
+function renderClients(userId) {
+  const clientList = document.getElementById('clientList');
+  clientList.innerHTML = '';
+  const fs = firebase.firestore();
+  fs.collection('clients').where('agronomistId', '==', userId).get().then((snap) => {
+    snap.forEach((doc) => {
+      const data = doc.data();
       const card = document.createElement('div');
       card.className = 'bg-white p-4 rounded-lg shadow flex flex-col';
-      card.innerHTML = `<h3 class="text-lg font-semibold mb-4">${clientData.name || 'Cliente'}</h3><button class="mt-auto px-3 py-2 text-white rounded" style="background-color: var(--brand-green);">Abrir</button>`;
+      card.innerHTML = `<h3 class="text-lg font-semibold mb-4">${data.name || 'Cliente'}</h3><button class="mt-auto px-3 py-2 text-white rounded" style="background-color: var(--brand-green);">Abrir</button>`;
       card.querySelector('button').addEventListener('click', () => {
-        window.location.href = `client-details.html?clientId=${clientDoc.id}&from=agronomo`;
+        window.location.href = `client-details.html?clientId=${doc.id}&from=agronomo`;
       });
       clientList.appendChild(card);
     });
-  } catch (err) {
-    console.error('Erro ao carregar clientes:', err);
-  }
+  });
 }
+
+function initLeadModal() {
+  const modal = document.getElementById('modal-novo-lead');
+  const btnNovo = document.getElementById('btn-novo-lead');
+  const cancel = document.getElementById('btn-cancel-lead');
+  const form = document.getElementById('form-novo-lead');
+
+  btnNovo.addEventListener('click', () => {
+    modal.classList.remove('hidden');
+    document.body.style.overflow = 'hidden';
+  });
+  cancel.addEventListener('click', () => {
+    modal.classList.add('hidden');
+    document.body.style.overflow = '';
+  });
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) {
+      modal.classList.add('hidden');
+      document.body.style.overflow = '';
+    }
+  });
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const lead = {
+      id: Date.now().toString(),
+      nomeContato: document.getElementById('lead-nomeContato').value,
+      propriedade: document.getElementById('lead-propriedade').value || undefined,
+      telefone: document.getElementById('lead-telefone').value || undefined,
+      email: document.getElementById('lead-email').value || undefined,
+      municipio: document.getElementById('lead-municipio').value,
+      uf: document.getElementById('lead-uf').value,
+      culturas: document.getElementById('lead-culturas').value ? document.getElementById('lead-culturas').value.split(',').map((s) => s.trim()) : [],
+      areaHa: document.getElementById('lead-areaHa').value ? Number(document.getElementById('lead-areaHa').value) : undefined,
+      origem: document.getElementById('lead-origem').value || 'Prospeccao',
+      lat: form.dataset.lat ? Number(form.dataset.lat) : undefined,
+      lng: form.dataset.lng ? Number(form.dataset.lng) : undefined,
+      criadoEm: new Date().toISOString(),
+      donoAgronomoId: currentUserId,
+      estagio: 'Novo',
+      syncFlag: navigator.onLine ? 'synced' : 'local-only'
+    };
+    await crmStore.insert('leads', lead);
+    if (navigator.onLine) {
+      try {
+        await firebase.firestore().collection('leads').doc(lead.id).set(lead);
+      } catch (err) {
+        lead.syncFlag = 'local-only';
+        await crmStore.upsert('leads', lead);
+      }
+    }
+    modal.classList.add('hidden');
+    document.body.style.overflow = '';
+    form.reset();
+    renderLeads();
+  });
+
+  const geoBtn = document.getElementById('btn-lead-geo');
+  geoBtn.addEventListener('click', () => {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        form.dataset.lat = pos.coords.latitude;
+        form.dataset.lng = pos.coords.longitude;
+      },
+      () => {
+        // Usuário negou; apenas segue
+      }
+    );
+  });
+}
+
+async function renderLeads() {
+  const tbody = document.getElementById('lead-list');
+  const leads = await crmStore.getAll('leads');
+  tbody.innerHTML = '';
+  leads.forEach((l) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="p-2">${l.nomeContato}${l.propriedade ? '/' + l.propriedade : ''}</td>
+      <td class="p-2">${l.municipio}/${l.uf}</td>
+      <td class="p-2">${(l.culturas || []).join(', ')}</td>
+      <td class="p-2"><span class="px-2 py-1 rounded bg-gray-200">${l.estagio}</span></td>
+      <td class="p-2 text-center">-</td>
+      <td class="p-2 text-center">-</td>
+      <td class="p-2 space-x-1">
+        <button class="text-blue-600 underline btn-lead-visitar" data-id="${l.id}">Visitar</button>
+        <button class="text-blue-600 underline btn-lead-proposta" data-id="${l.id}">Proposta</button>
+        <button class="text-blue-600 underline btn-lead-converter" data-id="${l.id}">Converter</button>
+        <button class="text-blue-600 underline btn-lead-ver" data-id="${l.id}">Ver</button>
+      </td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function initAgronomoDashboard() {
+  setupTabs();
+  setupOfflineIndicator();
+  initLeadModal();
+  renderLeads();
+  if (currentUserId) renderClients(currentUserId);
+}
+
+firebase.auth().onAuthStateChanged((user) => {
+  if (user) {
+    currentUserId = user.uid;
+    initAgronomoDashboard();
+  } else {
+    window.location.href = 'index.html';
+  }
+});
+
+export { initAgronomoDashboard, crmStore };
+


### PR DESCRIPTION
## Summary
- transform agronomist dashboard into tabbed layout for leads, map, agenda, proposals, clients and comments
- add offline indicator and lead creation modal with geolocation support
- implement offline-first crmStore using IndexedDB/localStorage and use Firebase compat APIs

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32dcc4ddc832e9ac200cfd69e8169