### PR TITLE
feat: dynamic manifest and sw reload guards

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Page Not Found</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
 
     <style media="screen">
       body { background: #ECEFF1; color: rgba(0,0,0,0.87); font-family: Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 0; }

--- a/public/activity-details.html
+++ b/public/activity-details.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Detalhes do Serviço</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="manifest" href="/manifest.json">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 <body class="bg-gray-100">

--- a/public/agenda.html
+++ b/public/agenda.html
@@ -4,11 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Agenda</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <link href="https://cdn.tailwindcss.com/" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/style.css">
-    <link rel="apple-touch-icon" href="/favicon.png">
-    <link rel="manifest" href="/manifest.json"> <meta name="theme-color" content="#1a472a">
+    <link rel="apple-touch-icon" href="/favicon.png"> <meta name="theme-color" content="#1a472a">
 
     <link href='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.css' rel='stylesheet' />
     </head>

--- a/public/agronomo-farm.html
+++ b/public/agronomo-farm.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Orgânia - Fazenda</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css" />
-  <link rel="icon" type="image/png" href="favicon.png" />
 </head>
 <body class="bg-gray-100 text-gray-800 pb-16">
   <header class="bg-white shadow-md">

--- a/public/client-details.html
+++ b/public/client-details.html
@@ -4,11 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Detalhes do Cliente</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
-<link rel="manifest" href="/manifest.json">
 </head>
 <body class="bg-gray-100">
     

--- a/public/dashboard-admin.html
+++ b/public/dashboard-admin.html
@@ -4,12 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Painel Administrativo</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<link rel="manifest" href="/manifest.json">
 </head>
 <body class="bg-gray-100">
     <div id="dashboard-admin-marker" class="hidden"></div>

--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -4,10 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Orgânia - Painel do Agrônomo</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
   <link rel="stylesheet" href="style.css" />
-  <link rel="icon" type="image/png" href="favicon.png" />
 </head>
 <body class="bg-gray-100 text-gray-800">
   <div id="dashboard-agronomo-marker" class="hidden"></div>

--- a/public/dashboard-cliente.html
+++ b/public/dashboard-cliente.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia Fertilizantes - Painel do Cliente</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="manifest" href="/manifest.json">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 <body class="bg-gray-100">

--- a/public/formulas-admin.html
+++ b/public/formulas-admin.html
@@ -4,11 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Gestão de Fórmulas</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
-<link rel="manifest" href="/manifest.json">
 </head>
 <body class="bg-gray-100">
     <div id="formulas-admin-marker" class="hidden"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia Fertilizantes - Login</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
-<link rel="manifest" href="/manifest.json">
 </head>
 <body class="login-background">
 <div class="flex items-center justify-center min-h-screen p-4">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,85 @@
+// public/js/app.js
+
+function generateIcon(size, key) {
+  let dataUrl = localStorage.getItem(key);
+  if (!dataUrl) {
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, size, size);
+    ctx.fillStyle = '#166534';
+    ctx.beginPath();
+    ctx.arc(size / 2, size / 2, size / 2.2, 0, Math.PI * 2);
+    ctx.fill();
+    dataUrl = canvas.toDataURL('image/png');
+    localStorage.setItem(key, dataUrl);
+  }
+  return dataUrl;
+}
+
+export function ensureDynamicManifest() {
+  const manifestLink = document.getElementById('dynamic-manifest');
+  const faviconLink = document.getElementById('dynamic-favicon');
+  if (!manifestLink || !faviconLink) return;
+
+  const icon192 = generateIcon(192, 'organia_icon_192');
+  const icon512 = generateIcon(512, 'organia_icon_512');
+
+  const manifest = {
+    name: 'Orgânia',
+    short_name: 'Orgânia',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    background_color: '#ffffff',
+    theme_color: '#166534',
+    icons: [
+      { src: icon192, sizes: '192x192', type: 'image/png', purpose: 'any maskable' },
+      { src: icon512, sizes: '512x512', type: 'image/png', purpose: 'any maskable' }
+    ]
+  };
+
+  const blob = new Blob([JSON.stringify(manifest)], { type: 'application/manifest+json' });
+  const url = URL.createObjectURL(blob);
+  manifestLink.href = url;
+  faviconLink.href = icon192;
+
+  window.addEventListener('beforeunload', () => {
+    URL.revokeObjectURL(url);
+  });
+}
+
+export function registerSW() {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', async () => {
+      try {
+        const registration = await navigator.serviceWorker.register('/service-worker.js');
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (!window.__didReloadOnce) {
+            window.__didReloadOnce = true;
+            window.location.reload();
+          }
+        });
+        registration.addEventListener('updatefound', () => {
+          const newWorker = registration.installing;
+          if (newWorker) {
+            newWorker.addEventListener('statechange', () => {
+              if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                newWorker.postMessage({ type: 'SKIP_WAITING' });
+              }
+            });
+          }
+        });
+      } catch (err) {
+        console.error('Falha ao registrar Service Worker', err);
+      }
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  ensureDynamicManifest();
+  registerSW();
+});
+

--- a/public/js/services/auth.js
+++ b/public/js/services/auth.js
@@ -32,39 +32,6 @@ import { showLoader, hideLoader } from './ui.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 
-    // CÓDIGO PARA REGISTRAR O SERVICE WORKER (FUNCIONALIDADE PWA)
-    if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-            navigator.serviceWorker
-                .register('/service-worker.js')
-                .then(registration => {
-                    console.log('ServiceWorker registrado com sucesso: ', registration.scope);
-
-                    let refreshing = false;
-                    navigator.serviceWorker.addEventListener('controllerchange', () => {
-                        if (refreshing) return;
-                        refreshing = true;
-                        window.location.reload();
-                    });
-
-                    registration.addEventListener('updatefound', () => {
-                        const newWorker = registration.installing;
-                        if (!newWorker) return;
-                        newWorker.addEventListener('statechange', () => {
-                            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                                if (confirm('Uma nova versão está disponível. Recarregar agora?')) {
-                                    newWorker.postMessage({ type: 'SKIP_WAITING' });
-                                }
-                            }
-                        });
-                    });
-                })
-                .catch(error => {
-                    console.log('Falha no registro do ServiceWorker: ', error);
-                });
-        });
-    }
-
       async function handleLogin(e) {
           e.preventDefault();
           const loginForm = document.getElementById('loginForm');

--- a/public/mapa-geral.html
+++ b/public/mapa-geral.html
@@ -4,16 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Mapa Geral de Propriedades</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
     <style>
         /* Garante que o mapa ocupe o espaço corretamente */
         #mapaGeral { height: calc(100vh - 128px); }
     </style>
-<link rel="manifest" href="/manifest.json">
 </head>
 <body class="bg-gray-100">
     

--- a/public/operador-agenda.html
+++ b/public/operador-agenda.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agenda do Operador</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer></script>
-  <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="min-h-screen bg-gray-100">

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Dashboard – Operador</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>

--- a/public/operador-ordens.html
+++ b/public/operador-ordens.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ordens do Operador</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer></script>
-  <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="min-h-screen bg-[#F9FAFB]">

--- a/public/operador-perfil.html
+++ b/public/operador-perfil.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Perfil do Operador</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer></script>
-  <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="min-h-screen bg-gray-100">

--- a/public/operador-tarefas.html
+++ b/public/operador-tarefas.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tarefas do Operador</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer></script>
-  <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="min-h-screen bg-gray-100">

--- a/public/ordens-producao.html
+++ b/public/ordens-producao.html
@@ -4,11 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Ordens de Produção</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
-<link rel="manifest" href="/manifest.json">
 </head>
 <body class="bg-gray-100">
     <div id="production-orders-marker" class="hidden"></div>

--- a/public/order-details.html
+++ b/public/order-details.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Detalhes da Ordem</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer></script>
-  <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-gray-100">

--- a/public/plot-details.html
+++ b/public/plot-details.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia Fertilizantes - Painel da Cultura</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
     <style>
         .timeline-item::before { content: ''; position: absolute; top: 1rem; left: -1.6rem; width: 0.875rem; height: 0.875rem; background-color: var(--brand-green); border-radius: 9999px; border: 3px solid white; }
         .details-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.5rem; }
@@ -23,7 +26,6 @@
         .lightbox img { max-width: 90%; max-height: 90%; object-fit: contain; }
         .lightbox .close-btn { position: absolute; top: 2rem; right: 2rem; color: white; font-size: 2.5rem; cursor: pointer; }
     </style>
-    <link rel="manifest" href="/manifest.json">
 </head>
 <body class="bg-gray-100">
 

--- a/public/property-details.html
+++ b/public/property-details.html
@@ -4,12 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Detalhes da Propriedade</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="manifest" href="/manifest.json">
     </head>
 <body class="bg-gray-100">
     

--- a/public/property-employees.html
+++ b/public/property-employees.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Funcionários da Fazenda</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css" />
-  <link rel="icon" type="image/png" href="favicon.png" />
 </head>
 <body class="bg-gray-100 text-gray-800 pb-16">
   <header class="bg-white shadow-md">

--- a/public/relatorio-talhao.html
+++ b/public/relatorio-talhao.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Relatório de Evolução</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="favicon.png">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-annotation/1.4.0/chartjs-plugin-annotation.min.js"></script>
@@ -36,7 +39,6 @@
             accent-color: var(--brand-green);
         }
     </style>
-<link rel="manifest" href="/manifest.json">
 </head>
 <body class="bg-gray-100">
     

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,6 @@
 // service-worker.js
 
-const CACHE_NAME = 'organia-v3';
+const CACHE_NAME = 'organia-v5';
 const APP_VERSION = '1.0.1';
 const urlsToCache = [
   // Arquivos principais
@@ -10,10 +10,7 @@ const urlsToCache = [
 
   // Imagens e Ícones
   '/logo.png',
-  '/favicon.png',
   '/background.jpg',
-  '/icon-192.png',
-  '/icon-512.png',
 
   // Páginas HTML
   '/dashboard-admin.html',

--- a/public/task-viewer.html
+++ b/public/task-viewer.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orgânia - Visualizador de Tarefas</title>
+  <link id="dynamic-manifest" rel="manifest" href="">
+  <link id="dynamic-favicon" rel="icon" type="image/png" href="">
+  <meta name="theme-color" content="#166534">
+  <script type="module" src="js/app.js"></script>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-
-    <link rel="icon" type="image/png" href="favicon.png">
-<link rel="manifest" href="/manifest.json">
  <link rel="stylesheet" href="css/tokens.css">
   <link rel="stylesheet" href="css/theme.css">
   <link rel="stylesheet" href="css/base.css">


### PR DESCRIPTION
## Summary
- build manifest dynamically with canvas-generated icons and set favicon via data URL
- register service worker once with reload guard and updated cache version
- inject dynamic manifest links and theme color into all app pages

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a364f4f4ac832e8107d2425fef34b5