### PR TITLE
fix: avoid index reload loop on unknown roles

### DIFF
--- a/public/js/services/auth.js
+++ b/public/js/services/auth.js
@@ -142,9 +142,16 @@ document.addEventListener('DOMContentLoaded', () => {
                         agronomo: 'dashboard-agronomo.html',
                         cliente: 'dashboard-cliente.html',
                         // NOVO: Adiciona o roteamento para o papel 'operador'
-                        operador: 'operador-dashboard.html' 
+                        operador: 'operador-dashboard.html'
                     };
-                    window.location.href = roleToDashboard[userRole] || 'index.html';
+
+                    const destination = roleToDashboard[userRole];
+                    if (destination) {
+                        window.location.href = destination;
+                    } else {
+                        console.error(`Papel de usuário desconhecido: ${userRole}`);
+                        await logout();
+                    }
                 } else {
                     initializePage(user, userRole);
                 }


### PR DESCRIPTION
## Summary
- handle unknown user roles on login redirect
- logout when role is invalid to prevent endless reloads

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a375420de0832e8e4048101b0075e4