### PR TITLE
feat: add service worker and manifest fixes

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,19 +1,14 @@
 // public/js/app.js
 
-export function unregisterSW() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.getRegistrations()
-      .then(registrations => {
-        for (const registration of registrations) {
-          registration.unregister();
-        }
-      })
-      .catch(err => {
-        console.error('Falha ao desregistrar Service Worker', err);
-      });
-  }
-}
+if ('serviceWorker' in navigator) {
+  let didReloadOnce = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (didReloadOnce) return;
+    didReloadOnce = true;
+    location.reload();
+  });
 
-document.addEventListener('DOMContentLoaded', () => {
-  unregisterSW();
-});
+  navigator.serviceWorker.register('/sw.js').catch(err => {
+    console.error('Falha ao registrar Service Worker', err);
+  });
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,25 @@
+const CACHE_NAME = 'organia-v7';
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.map(key => (key !== CACHE_NAME ? caches.delete(key) : undefined)))
+    )
+  );
+  clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.open(CACHE_NAME).then(cache =>
+      fetch(event.request)
+        .then(response => {
+          cache.put(event.request, response.clone());
+          return response;
+        })
+        .catch(() => cache.match(event.request))
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add service worker registration with single reload on controller change
- implement caching service worker with versioned cache and cleanup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a3810b4618832e92065ec1a039302f