### PR TITLE
Refactor service worker to prevent reload loops

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,32 +1,19 @@
 // public/js/app.js
 
 if ('serviceWorker' in navigator) {
-  let refreshed = false;
-  navigator.serviceWorker.addEventListener('controllerchange', () => {
-    if (refreshed) return;
-    refreshed = true;
-    // Estratégia suave: exiba um toast/banner “Nova versão disponível. Atualizar?”
-    // Se já quiser atualizar silenciosamente, use:
-    // window.location.reload();
-  });
-
-  navigator.serviceWorker.addEventListener('message', (event) => {
-    if (event.data && event.data.type === 'SW_READY') {
-      // TODO: mostrar UI de update; se usuário aceitar:
-      // window.location.reload();
-    }
-  });
+  // sem reload automático em controllerchange
 
   navigator.serviceWorker.register('/sw.js').catch(err => {
     console.error('Falha ao registrar Service Worker', err);
   });
 
-  navigator.serviceWorker.ready.then(reg => reg.update());
-  navigator.serviceWorker.getRegistrations().then(async regs => {
-    for (const r of regs) {
-      if (!r.active || (r.active && !r.active.scriptURL.endsWith('/sw.js'))) {
-        try { await r.unregister(); } catch {}
+  // Limpeza 1x de SWs antigos que não sejam /sw.js
+  navigator.serviceWorker.getRegistrations?.().then(regs => {
+    regs.forEach(r => {
+      const url = r.active?.scriptURL || '';
+      if (url && !url.endsWith('/sw.js')) {
+        r.unregister().catch(() => {});
       }
-    }
+    });
   });
 }


### PR DESCRIPTION
## Summary
- consolidate Firebase messaging and bump cache version in service worker without aggressive takeover
- avoid caching HTML and SW files while handling only GET requests
- streamline service worker registration and remove automatic reload logic

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a454758e4c832ea2491f42cf136fb4