### PR TITLE
fix: initialize firebase messaging correctly

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,15 +1,28 @@
 // public/js/app.js
 
+import { messaging } from './config/firebase.js';
+import { getToken, onMessage } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
+
 if ('serviceWorker' in navigator) {
   // sem reload automático em controllerchange
 
-  navigator.serviceWorker.register('/sw.js').catch(err => {
-    console.error('Falha ao registrar Service Worker', err);
-  });
+  navigator.serviceWorker
+    .register('/sw.js')
+    .then(async (registration) => {
+      const vapidKey = window.FCM_VAPID_PUBLIC_KEY || undefined;
+      try {
+        await getToken(messaging, { serviceWorkerRegistration: registration, vapidKey });
+      } catch (err) {
+        console.error('[FCM] getToken error:', err);
+      }
+    })
+    .catch((err) => {
+      console.error('Falha ao registrar Service Worker', err);
+    });
 
   // Limpeza 1x de SWs antigos que não sejam /sw.js
-  navigator.serviceWorker.getRegistrations?.().then(regs => {
-    regs.forEach(r => {
+  navigator.serviceWorker.getRegistrations?.().then((regs) => {
+    regs.forEach((r) => {
       const url = r.active?.scriptURL || '';
       if (url && !url.endsWith('/sw.js')) {
         r.unregister().catch(() => {});
@@ -18,15 +31,20 @@ if ('serviceWorker' in navigator) {
   });
 
   // Diagnóstico leve para depuração
-  window.__sw_debug_once__ || (window.__sw_debug_once__ = (async () => {
-    try {
-      const regs = await navigator.serviceWorker.getRegistrations?.();
-      console.log('[SW DEBUG] Registrations:', regs?.map(r => r.active?.scriptURL || r.scriptURL));
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
-        console.log('[SW DEBUG] controllerchange fired — sem reload automático.');
-      });
-    } catch (e) {
-      console.warn('[SW DEBUG] erro:', e);
-    }
-  })());
+  window.__sw_debug_once__ ||
+    (window.__sw_debug_once__ = (async () => {
+      try {
+        const regs = await navigator.serviceWorker.getRegistrations?.();
+        console.log('[SW DEBUG] Registrations:', regs?.map((r) => r.active?.scriptURL || r.scriptURL));
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          console.log('[SW DEBUG] controllerchange fired — sem reload automático.');
+        });
+      } catch (e) {
+        console.warn('[SW DEBUG] erro:', e);
+      }
+    })());
+
+  onMessage(messaging, (payload) => {
+    console.debug('[FCM] onMessage foreground:', payload);
+  });
 }

--- a/public/js/config/Livefirebase.js
+++ b/public/js/config/Livefirebase.js
@@ -3,7 +3,7 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase
 // REMOVIDO 'enablePersistence' desta importação, pois não é exportado por este bundle CDN
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-auth.js';
-import { getMessaging, getToken, onMessage } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
+import { getMessaging } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
 
 // Seu objeto de configuração do Firebase (substitua com suas chaves reais!)
 const firebaseConfig = {
@@ -20,17 +20,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app); // Inicializa o Auth aqui
-const messaging = getMessaging();
-
-async function getFcmToken() {
-  const registration = await navigator.serviceWorker.ready;
-  const vapidKey = window.FCM_VAPID_PUBLIC_KEY || undefined;
-  return getToken(messaging, { serviceWorkerRegistration: registration, vapidKey });
-}
-
-onMessage(messaging, (payload) => {
-  console.debug('[FCM] onMessage foreground:', payload);
-});
+const messaging = getMessaging(app);
 
 // O BLOCO ABAIXO FOI COMENTADO PARA RESOLVER O ERRO DE IMPORTAÇÃO
 // Se a persistência offline for crucial, você precisará investigar a forma correta
@@ -48,4 +38,4 @@ enablePersistence(db)
   });
 */
 
-export { db, app, auth, messaging, getFcmToken }; // Exportar 'db', 'app', 'auth' e utilitários de messaging
+export { db, app, auth, messaging }; // Exportar 'db', 'app', 'auth' e utilitários de messaging

--- a/public/js/config/firebase.js
+++ b/public/js/config/firebase.js
@@ -3,7 +3,7 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase
 // REMOVIDO 'enablePersistence' desta importação, pois não é exportado por este bundle CDN
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-auth.js';
-import { getMessaging, getToken, onMessage } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
+import { getMessaging } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
 
 // Seu objeto de configuração do Firebase (substitua com suas chaves reais!)
 const firebaseConfig = {
@@ -19,17 +19,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app); // Inicializa o Auth aqui
-const messaging = getMessaging();
-
-async function getFcmToken() {
-  const registration = await navigator.serviceWorker.ready;
-  const vapidKey = window.FCM_VAPID_PUBLIC_KEY || undefined;
-  return getToken(messaging, { serviceWorkerRegistration: registration, vapidKey });
-}
-
-onMessage(messaging, (payload) => {
-  console.debug('[FCM] onMessage foreground:', payload);
-});
+const messaging = getMessaging(app);
 
 // O BLOCO ABAIXO FOI COMENTADO PARA RESOLVER O ERRO DE IMPORTAÇÃO
 // Se a persistência offline for crucial, você precisará investigar a forma correta
@@ -47,4 +37,4 @@ enablePersistence(db)
   });
 */
 
-export { db, app, auth, messaging, getFcmToken }; // Exportar 'db', 'app', 'auth' e utilitários de messaging
+export { db, app, auth, messaging }; // Exportar 'db', 'app', 'auth' e utilitários de messaging


### PR DESCRIPTION
## Summary
- centralize Firebase initialization and messaging setup
- use service worker registration for FCM token
- listen for foreground messages via shared messaging instance

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a45db12f58832e9e9b1fa3052ae9d2