### PR TITLE
Handle unsupported Firebase messaging

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,11 +9,15 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker
     .register('/sw.js')
     .then(async (registration) => {
-      const vapidKey = window.FCM_VAPID_PUBLIC_KEY || undefined;
-      try {
-        await getToken(messaging, { serviceWorkerRegistration: registration, vapidKey });
-      } catch (err) {
-        console.error('[FCM] getToken error:', err);
+      if (messaging) {
+        const vapidKey = window.FCM_VAPID_PUBLIC_KEY || undefined;
+        try {
+          await getToken(messaging, { serviceWorkerRegistration: registration, vapidKey });
+        } catch (err) {
+          console.error('[FCM] getToken error:', err);
+        }
+      } else {
+        console.warn('[FCM] messaging não suportado; getToken não será chamado.');
       }
     })
     .catch((err) => {
@@ -44,7 +48,9 @@ if ('serviceWorker' in navigator) {
       }
     })());
 
-  onMessage(messaging, (payload) => {
-    console.debug('[FCM] onMessage foreground:', payload);
-  });
+  if (messaging) {
+    onMessage(messaging, (payload) => {
+      console.debug('[FCM] onMessage foreground:', payload);
+    });
+  }
 }

--- a/public/js/config/Livefirebase.js
+++ b/public/js/config/Livefirebase.js
@@ -20,7 +20,14 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app); // Inicializa o Auth aqui
-const messaging = getMessaging(app);
+
+let messaging;
+try {
+  // Evita erro "Service messaging is not available" em ambientes sem suporte
+  messaging = getMessaging(app);
+} catch (err) {
+  console.warn('Firebase messaging não suportado neste ambiente.', err);
+}
 
 // O BLOCO ABAIXO FOI COMENTADO PARA RESOLVER O ERRO DE IMPORTAÇÃO
 // Se a persistência offline for crucial, você precisará investigar a forma correta

--- a/public/js/config/firebase.js
+++ b/public/js/config/firebase.js
@@ -19,7 +19,14 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app); // Inicializa o Auth aqui
-const messaging = getMessaging(app);
+
+let messaging;
+try {
+  // Evita erro "Service messaging is not available" em ambientes sem suporte
+  messaging = getMessaging(app);
+} catch (err) {
+  console.warn('Firebase messaging não suportado neste ambiente.', err);
+}
 
 // O BLOCO ABAIXO FOI COMENTADO PARA RESOLVER O ERRO DE IMPORTAÇÃO
 // Se a persistência offline for crucial, você precisará investigar a forma correta


### PR DESCRIPTION
## Summary
- prevent Firebase messaging initialization crash when service is unavailable
- guard FCM token requests and listeners for unsupported environments

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a4637226fc832e80eb4aee4974a465