### PR TITLE
feat: add logs for initial page and login flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,15 @@
   <script type="module" src="js/app.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
+    <script>
+      console.log('[index] script inicial executado');
+      document.addEventListener('DOMContentLoaded', () => {
+        console.log('[index] DOMContentLoaded disparado');
+      });
+      window.addEventListener('load', () => {
+        console.log('[index] window load disparado');
+      });
+    </script>
 </head>
 <body class="login-background">
 <div class="flex items-center justify-center min-h-screen p-4">

--- a/public/js/services/auth.js
+++ b/public/js/services/auth.js
@@ -34,25 +34,28 @@ console.log('auth.js carregado');
 console.log('[auth] página atual:', window.location.href);
 
 document.addEventListener('DOMContentLoaded', () => {
+      console.log('[auth] DOMContentLoaded disparado');
       let redirecting = false;
 
       const isOnIndex = () =>
           window.location.pathname.endsWith('index.html') || window.location.pathname === '/';
 
-      async function handleLogin(e) {
-          e.preventDefault();
-          const loginForm = document.getElementById('loginForm');
-          const loginError = document.getElementById('loginError');
-          const email = loginForm.email.value;
-          const password = loginForm.password.value;
+        async function handleLogin(e) {
+            e.preventDefault();
+            const loginForm = document.getElementById('loginForm');
+            const loginError = document.getElementById('loginError');
+            const email = loginForm.email.value;
+            const password = loginForm.password.value;
 
-          try {
-              showLoader();
-              loginError.classList.add('hidden');
-              // SINTAXE CORRIGIDA FIREBASE V9 AUTH: passa 'auth' como primeiro argumento
-              await signInWithEmailAndPassword(auth, email, password);
-          } catch (error) {
-              console.error("Erro de login detalhado:", error);
+            try {
+                console.log('[auth] tentativa de login iniciada', { email });
+                showLoader();
+                loginError.classList.add('hidden');
+                // SINTAXE CORRIGIDA FIREBASE V9 AUTH: passa 'auth' como primeiro argumento
+                await signInWithEmailAndPassword(auth, email, password);
+                console.log('[auth] login bem-sucedido, aguardando onAuthStateChanged');
+            } catch (error) {
+                console.error("Erro de login detalhado:", error);
 
               if (error.code === 'auth/wrong-password' || error.code === 'auth/user-not-found' || error.code === 'auth/invalid-credential') {
                   loginError.textContent = 'Email ou senha incorretos.';
@@ -60,10 +63,10 @@ document.addEventListener('DOMContentLoaded', () => {
                   loginError.textContent = 'Ocorreu um erro. Tente novamente.';
               }
               loginError.classList.remove('hidden');
-          } finally {
-              hideLoader();
-          }
-      }
+            } finally {
+                hideLoader();
+            }
+        }
 
       const logout = async () => {
           console.log('[auth] logout chamado');


### PR DESCRIPTION
## Summary
- log key events on index page load
- log login attempts and DOMContentLoaded in auth service

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a4718829d0832e9c6f2a9b17a81e5c