### PR TITLE
fix: avoid login redirect loops

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
       });
     </script>
 </head>
-<body class="login-background">
+<body class="login-background" data-page="login">
 <div class="flex items-center justify-center min-h-screen p-4">
 
         <div class="relative z-10 card w-full max-w-md">            

--- a/public/js/pages/agenda.js
+++ b/public/js/pages/agenda.js
@@ -42,7 +42,7 @@ export async function initAgenda(uid, userRole) {
     if (!currentUser || !currentUser.userRole) {
         console.error('initAgenda: Usuário não autenticado ou papel não definido.');
         hideSpinner();
-        window.location.href = 'index.html';
+        window.safeRedirectToIndex('agenda-no-user');
         return;
     }
 

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -274,7 +274,7 @@ onAuthStateChanged(auth, (user) => {
     currentUserId = user.uid;
     initAgronomoDashboard();
   } else {
-    window.location.href = 'index.html';
+    window.safeRedirectToIndex('dashboard-agronomo-unauthenticated');
   }
 });
 


### PR DESCRIPTION
## Summary
- mark login page with data-page attribute
- add robust login page detection and safe redirect helper
- replace direct index redirects across pages with safeRedirectToIndex

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a481dd13bc832e9a3184c816f67ba1