### PR TITLE
feat: add proposal management to agronomist dashboard

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -170,6 +170,16 @@ async function syncPending() {
       console.warn(TAG, 'Falha ao sincronizar visita', err);
     }
   }
+  const propostas = await crmStore.getAll('propostas');
+  for (const p of propostas.filter((x) => x.syncFlag === 'local-only')) {
+    try {
+      await setDoc(doc(db, 'proposals', p.id), { ...p, agronomistId: p.ownerUid, syncFlag: 'synced' });
+      p.syncFlag = 'synced';
+      await crmStore.upsert('propostas', p);
+    } catch (err) {
+      console.warn(TAG, 'Falha ao sincronizar proposta', err);
+    }
+  }
 }
 
 function renderClients(userId) {
@@ -191,6 +201,136 @@ function renderClients(userId) {
       }
       clientList.appendChild(card);
     });
+  });
+}
+
+async function updateProposalStatus(id, newStatus) {
+  const prop = await crmStore.getById('propostas', id);
+  if (!prop) return;
+  prop.status = newStatus;
+  prop.syncFlag = navigator.onLine ? 'synced' : 'local-only';
+  await crmStore.upsert('propostas', prop);
+  if (navigator.onLine) {
+    try {
+      await setDoc(doc(db, 'proposals', prop.id), { status: newStatus }, { merge: true });
+    } catch (err) {
+      prop.syncFlag = 'local-only';
+      await crmStore.upsert('propostas', prop);
+    }
+  }
+  console.log('[PROPOSTAS]', 'status', prop.id, newStatus);
+  if (newStatus === 'Aceita') {
+    document.dispatchEvent(new CustomEvent('proposalAccepted', { detail: prop }));
+  }
+  renderProposals();
+  syncPending();
+}
+
+async function renderProposals() {
+  const tbl = getEl('tbl-propostas');
+  if (!tbl) return;
+  const tbody = tbl.querySelector('tbody');
+  if (!tbody) return;
+  const props = await crmStore.getAll('propostas');
+  const leads = await crmStore.getAll('leads');
+  const leadMap = {};
+  leads.forEach((l) => { leadMap[l.id] = l.nomeContato || l.propriedade || l.id; });
+  tbody.innerHTML = '';
+  props.forEach((p) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="p-2">${leadMap[p.leadId] || p.leadId}</td>
+      <td class="p-2">${p.valorTotal}</td>
+      <td class="p-2">${p.status}</td>
+      <td class="p-2">${p.validade ? new Date(p.validade).toLocaleDateString() : '-'}</td>
+      <td class="p-2 space-x-2">
+        <button class="text-green-600 underline btn-prop-aceita" data-id="${p.id}">Aceita</button>
+        <button class="text-red-600 underline btn-prop-rejeita" data-id="${p.id}">Rejeitada</button>
+      </td>`;
+    tbody.appendChild(tr);
+  });
+  tbody.querySelectorAll('.btn-prop-aceita').forEach((btn) => {
+    btn.addEventListener('click', () => updateProposalStatus(btn.dataset.id, 'Aceita'));
+  });
+  tbody.querySelectorAll('.btn-prop-rejeita').forEach((btn) => {
+    btn.addEventListener('click', () => updateProposalStatus(btn.dataset.id, 'Rejeitada'));
+  });
+}
+
+function openProposalModal(leadId) {
+  let modal = getEl('modal-proposta');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'modal-proposta';
+    document.body.appendChild(modal);
+  } else if (modal.parentElement !== document.body) {
+    document.body.appendChild(modal);
+  }
+  modal.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50';
+  modal.innerHTML = `
+    <div class="bg-white p-4 rounded w-full max-w-md">
+      <h2 class="text-lg font-semibold mb-4">Nova Proposta</h2>
+      <form id="form-proposta" class="space-y-2">
+        <input id="prop-leadId" class="w-full border p-2 rounded" readonly />
+        <textarea id="prop-itens" class="w-full border p-2 rounded" placeholder="Itens"></textarea>
+        <input id="prop-valorTotal" type="number" class="w-full border p-2 rounded" placeholder="Valor Total" required />
+        <input id="prop-validade" type="date" class="w-full border p-2 rounded" required />
+        <div class="text-right space-x-2 pt-2">
+          <button type="button" id="btn-cancel-prop" class="px-4 py-2 bg-gray-300 rounded">Cancelar</button>
+          <button type="submit" class="px-4 py-2 text-white rounded" style="background-color: var(--brand-green);">Salvar</button>
+        </div>
+      </form>
+    </div>`;
+  modal.classList.remove('hidden');
+  document.body.style.overflow = 'hidden';
+  getEl('prop-leadId').value = leadId;
+  const close = () => {
+    modal.classList.add('hidden');
+    document.body.style.overflow = '';
+  };
+  getEl('btn-cancel-prop').addEventListener('click', close);
+  modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+  getEl('form-proposta').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const prop = {
+      id: Date.now().toString(),
+      leadId,
+      itens: getEl('prop-itens').value,
+      valorTotal: Number(getEl('prop-valorTotal').value),
+      validade: getEl('prop-validade').value,
+      createdAt: new Date().toISOString(),
+      status: 'Enviada',
+      ownerUid: currentUserId,
+      syncFlag: navigator.onLine ? 'synced' : 'local-only'
+    };
+    await crmStore.insert('propostas', prop);
+    if (navigator.onLine) {
+      try {
+        await setDoc(doc(db, 'proposals', prop.id), { ...prop, agronomistId: currentUserId });
+      } catch (err) {
+        prop.syncFlag = 'local-only';
+        await crmStore.upsert('propostas', prop);
+      }
+    }
+    const lead = await crmStore.getById('leads', leadId);
+    if (lead) {
+      lead.estagio = 'Proposta';
+      lead.stage = 'Proposta';
+      await crmStore.upsert('leads', lead);
+      if (navigator.onLine) {
+        try {
+          await setDoc(doc(db, 'leads', lead.id), { estagio: 'Proposta', stage: 'Proposta' }, { merge: true });
+        } catch (err) {
+          lead.syncFlag = 'local-only';
+          await crmStore.upsert('leads', lead);
+        }
+      }
+    }
+    console.log('[PROPOSTAS]', 'criada', prop.id);
+    close();
+    renderProposals();
+    renderLeads();
+    syncPending();
   });
 }
 
@@ -448,6 +588,9 @@ async function renderLeads() {
   tbody.querySelectorAll('.btn-lead-visitar').forEach((btn) => {
     btn.addEventListener('click', () => startVisit(btn.dataset.id));
   });
+  tbody.querySelectorAll('.btn-lead-proposta').forEach((btn) => {
+    btn.addEventListener('click', () => openProposalModal(btn.dataset.id));
+  });
 }
 
 function initAgronomoDashboard() {
@@ -463,6 +606,7 @@ function initAgronomoDashboard() {
       initLeadModal();
       setupVisitModal();
       renderLeads();
+      renderProposals();
       renderClients(currentUserId);
     } else {
       window.safeRedirectToIndex('dashboard-agronomo-unauthenticated');


### PR DESCRIPTION
## Summary
- add offline/online sync and modal to create fertilizer proposals
- render proposals tab with status actions and event dispatch when accepted
- log proposal creation and status changes

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b6c20ae0832ebe801e64ff7aab3f