### PR TITLE
fix: guard notifications and dashboard elements

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -811,8 +811,7 @@ async function renderLeads() {
 }
 
 function initAgronomoDashboard() {
-  if (!document.getElementById('dashboard-agronomo-marker')) {
-    console.log(TAG, 'marcador ausente; abortando init');
+  if (!getEl('dashboard-agronomo-marker')) {
     return;
   }
   onAuthStateChanged(auth, (user) => {


### PR DESCRIPTION
## Summary
- handle missing notification DOM elements with getEl and warnings
- use getEl for dashboard marker to avoid errors when absent

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c42d699c832e9d33500641893ca7