### PR TITLE
feat: add header KPIs and actions to agronomist dashboard

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -41,8 +41,6 @@
           <h1 class="text-xl font-bold">Painel do Agrônomo</h1>
         </div>
         <div class="flex space-x-2">
-          <button id="btn-novo-lead" class="dashboard-btn flex items-center text-sm"><i class="fas fa-user-plus mr-2"></i>+ Novo Lead</button>
-          <button id="btn-iniciar-visita" class="dashboard-btn flex items-center text-sm"><i class="fas fa-walking mr-2"></i>Iniciar Visita</button>
           <button onclick="logout()" class="dashboard-btn flex items-center text-sm"><i class="fas fa-sign-out-alt mr-2"></i>Sair</button>
         </div>
       </div>
@@ -50,6 +48,26 @@
     <div id="offline-indicator" class="fixed top-0 right-0 m-2 bg-yellow-200 text-yellow-800 text-xs px-2 py-1 rounded hidden">Offline</div>
 
     <div class="dashboard-container py-6">
+      <div class="flex justify-between items-start mb-6">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div class="bg-white p-4 rounded shadow">
+            <p class="text-sm text-gray-500">Leads (7d)</p>
+            <span id="kpiLeads7d" class="text-2xl font-bold">0</span>
+          </div>
+          <div class="bg-white p-4 rounded shadow">
+            <p class="text-sm text-gray-500">Propostas ativas</p>
+            <span id="kpiPropsAtivas" class="text-2xl font-bold">0</span>
+          </div>
+          <div class="bg-white p-4 rounded shadow">
+            <p class="text-sm text-gray-500">Conversões (30d)</p>
+            <span id="kpiConv30d" class="text-2xl font-bold">0</span>
+          </div>
+        </div>
+        <div class="flex space-x-2">
+          <button id="btnNovoLead" class="px-4 py-2 bg-green-600 text-white rounded">Novo Lead</button>
+          <button id="btnIniciarVisita" class="px-4 py-2 border border-green-600 text-green-600 rounded">Iniciar Visita</button>
+        </div>
+      </div>
       <nav class="flex space-x-4 overflow-x-auto mb-6" role="tablist">
         <button class="tab-btn active" data-tab="leads">Leads</button>
         <button class="tab-btn" data-tab="mapa">Mapa</button>
@@ -89,6 +107,10 @@
             </thead>
             <tbody id="lead-list"></tbody>
           </table>
+        </div>
+        <div id="lead-empty" class="text-center py-8 hidden">
+          <p class="mb-4">Sem leads ainda</p>
+          <button id="btnNovoLeadEmpty" class="px-4 py-2 bg-green-600 text-white rounded">Novo Lead</button>
         </div>
         <div id="lead-funil" class="mt-6 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4"></div>
       </section>

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -521,15 +521,9 @@ function openProposalModal(leadId) {
 
 function initLeadModal() {
   const modal = getEl('modal-novo-lead');
-  const btnNovo = getEl('btn-novo-lead');
   const cancel = getEl('btn-cancel-lead');
   const form = getEl('form-novo-lead');
-  if (!modal || !btnNovo || !cancel || !form) return;
-
-  btnNovo.addEventListener('click', () => {
-    modal.classList.remove('hidden');
-    document.body.style.overflow = 'hidden';
-  });
+  if (!modal || !cancel || !form) return;
   cancel.addEventListener('click', () => {
     modal.classList.add('hidden');
     document.body.style.overflow = '';
@@ -775,8 +769,14 @@ async function finishVisit() {
 async function renderLeads() {
   const tbody = getEl('lead-list');
   if (!tbody) return;
+  const empty = getEl('lead-empty');
   const leads = await crmStore.getAll('leads');
   tbody.innerHTML = '';
+  if (!leads.length) {
+    if (empty) empty.classList.remove('hidden');
+    return;
+  }
+  if (empty) empty.classList.add('hidden');
   leads.forEach((l) => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
@@ -810,6 +810,37 @@ async function renderLeads() {
   });
 }
 
+function bindDashboardHeader(userId) {
+  const kpiLeads = document.getElementById('kpiLeads7d');
+  const kpiProps = document.getElementById('kpiPropsAtivas');
+  const kpiConv = document.getElementById('kpiConv30d');
+  if (kpiLeads) kpiLeads.textContent = '0';
+  if (kpiProps) kpiProps.textContent = '0';
+  if (kpiConv) kpiConv.textContent = '0';
+
+  const openLeadModal = () => {
+    const modal = document.getElementById('modal-novo-lead');
+    if (modal) {
+      modal.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+    }
+  };
+  const btnNovo = document.getElementById('btnNovoLead');
+  const btnNovoEmpty = document.getElementById('btnNovoLeadEmpty');
+  btnNovo?.addEventListener('click', openLeadModal);
+  btnNovoEmpty?.addEventListener('click', openLeadModal);
+
+  const btnVisita = document.getElementById('btnIniciarVisita');
+  btnVisita?.addEventListener('click', () => {
+    setupVisitModal();
+    const modal = document.getElementById('modal-visita');
+    if (modal) {
+      modal.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+    }
+  });
+}
+
 function initAgronomoDashboard() {
   if (!getEl('dashboard-agronomo-marker')) {
     return;
@@ -817,6 +848,7 @@ function initAgronomoDashboard() {
   onAuthStateChanged(auth, (user) => {
     if (user) {
       currentUserId = user.uid;
+      bindDashboardHeader(currentUserId);
       setupTabs();
       setupOfflineIndicator();
       initLeadModal();
@@ -832,5 +864,5 @@ function initAgronomoDashboard() {
   });
 }
 
-export { initAgronomoDashboard };
+export { initAgronomoDashboard, bindDashboardHeader };
 


### PR DESCRIPTION
## Summary
- add KPI cards and quick-action buttons to agronomist dashboard
- show empty state for leads and hook buttons to open modals
- bind dashboard header events and KPIs via new helper

## Testing
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4c6e4eff0832eb6ee46186e536f15