### PR TITLE
feat: add offline leads module

### DIFF
--- a/public/js/pages/mapa-geral.js
+++ b/public/js/pages/mapa-geral.js
@@ -22,7 +22,7 @@ export function initMapaGeral() {
       snap.forEach((docSnap) => {
         const lead = docSnap.data();
         if (lead.lat && lead.lng) {
-          const color = lead.estagio === 'Visitado' ? 'green' : 'blue';
+          const color = lead.stage === 'Visitado' ? 'green' : 'blue';
           const marker = L.circleMarker([lead.lat, lead.lng], { color }).addTo(map);
           const popup = `<b>${lead.nomeContato || 'Lead'}</b><br><a href="dashboard-agronomo.html?leadId=${docSnap.id}" class="text-blue-600 underline">Abrir lead</a>`;
           marker.bindPopup(popup);


### PR DESCRIPTION
## Summary
- capture lead details with offline storage and geolocation
- render leads table with filters and logging
- adjust map to use lead stage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden retrieving @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cd07a3b8832eb28a54000cc47d1f