### PR TITLE
feat: ajustes no módulo de propostas

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -136,7 +136,7 @@
             <thead class="sr-only md:not-sr-only">
               <tr>
                 <th class="p-2 text-left">Lead</th>
-                <th class="p-2 text-left">Total</th>
+                <th class="p-2 text-left">Valor</th>
                 <th class="p-2 text-left">Status</th>
                 <th class="p-2 text-left">Validade</th>
                 <th class="p-2 text-left">Ações</th>

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -327,7 +327,7 @@ async function updateProposalStatus(id, newStatus) {
       await crmStore.upsert('propostas', prop);
     }
   }
-  console.log('[PROPOSTAS]', 'status', prop.id, newStatus);
+  console.log('[PROPOSTAS]', 'status alterado', prop.id, newStatus);
   if (newStatus === 'Aceita') {
     document.dispatchEvent(new CustomEvent('proposalAccepted', { detail: prop }));
   }
@@ -358,8 +358,8 @@ async function renderProposals() {
       <td class="p-2">${p.status}</td>
       <td class="p-2">${p.validade ? new Date(p.validade).toLocaleDateString() : '-'}</td>
       <td class="p-2 space-x-2">
-        <button class="text-green-600 underline btn-prop-aceita" data-id="${p.id}">Aceita</button>
-        <button class="text-red-600 underline btn-prop-rejeita" data-id="${p.id}">Rejeitada</button>
+        <button class="text-green-600 underline btn-prop-aceita" data-id="${p.id}">Aceitar</button>
+        <button class="text-red-600 underline btn-prop-rejeita" data-id="${p.id}">Rejeitar</button>
       </td>`;
     tbody.appendChild(tr);
   });

--- a/tests/integration/dom-agronomo.spec.ts
+++ b/tests/integration/dom-agronomo.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { loadDOM } from '../utils/dom.js';
+
+// Ensure dashboard-agronomo.html has proposals table with proper columns
+
+describe('dashboard agrônomo DOM', () => {
+  const dom = loadDOM('public/dashboard-agronomo.html');
+  it('contains proposals table with expected headers', () => {
+    const doc = dom.window.document;
+    const headers = Array.from(doc.querySelectorAll('#tbl-propostas thead th')).map((th) => th.textContent?.trim());
+    expect(headers).toEqual(['Lead', 'Valor', 'Status', 'Validade', 'Ações']);
+  });
+});

--- a/tests/unit/proposals.spec.ts
+++ b/tests/unit/proposals.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+describe('proposals actions', () => {
+  const src = readFileSync('public/js/pages/dashboard-agronomo.js', 'utf8');
+  it('includes Aceitar and Rejeitar action labels', () => {
+    expect(src).toMatch('>Aceitar<');
+    expect(src).toMatch('>Rejeitar<');
+  });
+});


### PR DESCRIPTION
## Summary
- renomeia coluna de propostas para Valor
- registra alteração de status com novo rótulo
- usa ações Aceitar/Rejeitar na listagem
- inclui testes para tabela de propostas

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a3709674832e993aff288162e91b