### PR TITLE
feat: improve dashboard ui

### DIFF
--- a/public/dashboard-admin.html
+++ b/public/dashboard-admin.html
@@ -37,7 +37,7 @@
         </div>
     </header>
 
-    <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+    <main class="max-w-7xl mx-auto dashboard-container">
         <div class="mb-6 border-b border-gray-200">
             <nav class="-mb-px flex space-x-6" aria-label="Tabs">
                 <button data-tab-target="dashboard" class="tab-btn active-tab whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm">Dashboard</button>
@@ -49,7 +49,7 @@
 
         <div id="tab-content-container" class="px-4 sm:px-0">
             <div id="dashboard-content" class="tab-content space-y-8">
-                <div class="bg-white p-6 rounded-lg shadow">
+                <div class="dashboard-card">
                     <h3 class="text-xl font-bold text-gray-800 mb-4">Analytics da Plataforma</h3>
                     <div id="kpiCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
                         <div class="bg-gray-50 p-4 rounded-lg border text-center"><p class="text-sm font-medium text-gray-500">Total de Clientes</p><p id="totalClientsStat" class="text-3xl font-bold text-gray-800">...</p></div>
@@ -73,8 +73,8 @@
             <div id="producao-content" class="tab-content hidden"><div id="production-orders-container"></div></div>
             
             <div id="ferramentas-content" class="tab-content hidden">
-                <div class="space-y-8">
-                    <div class="bg-white p-6 rounded-lg shadow">
+                    <div class="space-y-8">
+                    <div class="dashboard-card">
                         <h3 class="text-xl font-bold text-gray-800 mb-4">Mapas</h3>
                         <p class="text-sm text-gray-500 mb-4">Visualize a localização de todas as propriedades cadastradas em um mapa interativo.</p>
                         <a href="mapa-geral.html" class="inline-block px-4 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700">
@@ -86,23 +86,23 @@
             </div>
 
             <div id="clientes-content" class="tab-content hidden">
-                <div class="bg-white p-6 rounded-lg shadow">
+                <div class="dashboard-card">
                     <div class="flex flex-col sm:flex-row justify-between items-center mb-4 gap-3">
                         <h3 class="text-xl font-bold text-gray-800">Gestão de Clientes</h3>
                         <div class="flex items-center gap-2 w-full sm:w-auto">
                             <input type="search" id="adminClientSearch" placeholder="Buscar cliente..." class="w-full sm:w-auto p-2 border border-gray-300 rounded-md">
-                            <button id="adminAddClientBtn" class="px-4 py-2 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 text-sm whitespace-nowrap" title="Adicionar novo cliente"><i class="fas fa-plus"></i> <span class="hidden sm:inline-block ml-2">Cliente</span></button>
-                               <button id="adminAddOperatorBtn" class="px-4 py-2 bg-purple-500 text-white font-semibold rounded-lg hover:bg-purple-600 text-sm whitespace-nowrap" title="Adicionar novo funcionário"><i class="fas fa-user-tie"></i> <span class="hidden sm:inline-block ml-2">Funcionário</span></button>
+                            <button id="adminAddClientBtn" class="btn btn-primary flex items-center text-sm whitespace-nowrap" title="Adicionar novo cliente"><i class="fas fa-plus"></i> <span class="hidden sm:inline-block ml-2">Cliente</span></button>
+                               <button id="adminAddOperatorBtn" class="btn btn-secondary flex items-center text-sm whitespace-nowrap" title="Adicionar novo funcionário"><i class="fas fa-user-tie"></i> <span class="hidden sm:inline-block ml-2">Funcionário</span></button>
                         </div>
                     </div>
                     <div class="overflow-x-auto">
-                        <table class="min-w-full bg-white">
+                          <table class="min-w-full bg-white dashboard-table responsive-table">
                             <thead class="bg-gray-50">
                                 <tr>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Agrônomo Responsável</th>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status do Acesso</th>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
+                                    <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
+                                    <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider responsive-hide">Agrônomo Responsável</th>
+                                    <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider responsive-hide">Status do Acesso</th>
+                                    <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                                 </tr>
                             </thead>
                             <tbody id="adminClientsList" class="divide-y divide-gray-200"></tbody>

--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,7 @@
 
                 <p id="loginError" class="text-red-500 text-sm !mt-2 hidden"></p>
 
-  <button type="submit" style="background-color: var(--brand-green);" class="w-full text-white font-bold btn">                    
+  <button type="submit" class="w-full font-bold btn btn-primary">
                         Entrar
                 </button>
             </form>

--- a/public/js/pages/dashboard-admin.js
+++ b/public/js/pages/dashboard-admin.js
@@ -272,24 +272,29 @@ export function initAdminDashboard(userId, userRole) {
         function renderAdminClientList(clientsToRender) {
             adminClientsList.innerHTML = '';
             if (clientsToRender.length === 0) {
-                adminClientsList.innerHTML = '<tr><td colspan="4" class="text-center py-4 text-gray-500">Nenhum cliente encontrado.</td></tr>';
+                adminClientsList.innerHTML = '<tr><td colspan="4" class="empty-state"><span>Nenhum cliente encontrado.</span><button id="emptyAddClientBtn" class="btn btn-primary">Adicionar cliente</button></td></tr>';
+                const btn = document.getElementById("emptyAddClientBtn");
+                if(btn) btn.addEventListener('click', () => openClientModal());
                 return;
             }
             clientsToRender.forEach(client => {
                 const assignedAgronomist = allAgronomists.find(a => a.id === client.agronomistId);
                 const statusBadge = client.clientAuthUid ? `<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Ativo</span>` : `<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Pendente</span>`;
-                const linkButton = !client.clientAuthUid ? `<button data-action="setup-access" data-client-id="${client.id}" data-client-name="${client.name}" class="text-purple-600 hover:text-purple-900" title="Vincular Usuário"><i class="fas fa-link"></i></button>` : '';
-                
+                const linkButton = !client.clientAuthUid ? `<button data-action="setup-access" data-client-id="${client.id}" data-client-name="${client.name}" class="btn btn-secondary btn-icon" title="Vincular Usuário"><i class="fas fa-link"></i></button>` : '';
+
                 const row = document.createElement('tr');
                 row.className = 'hover:bg-gray-50';
                 row.innerHTML = `
                     <td class="px-6 py-4 whitespace-nowrap"><a href="client-details.html?clientId=${client.id}&from=admin" class="text-sm font-medium text-gray-900 hover:text-green-700" title="Ver detalhes do cliente">${client.name}</a></td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">${assignedAgronomist ? assignedAgronomist.name : 'Nenhum'}</td>
-                    <td class="px-6 py-4 whitespace-nowrap">${statusBadge}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-4">
-                        <button data-action="manage-modules" data-client-id="${client.id}" data-client-name="${client.name}" class="text-blue-600 hover:text-blue-900" title="Gerenciar Módulos"><i class="fas fa-cog"></i></button>
-                        <button data-action="edit-client" data-client-id="${client.id}" class="text-gray-600 hover:text-gray-900" title="Editar Cliente"><i class="fas fa-pencil-alt"></i></button>
-                        ${linkButton}
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 responsive-hide">${assignedAgronomist ? assignedAgronomist.name : 'Nenhum'}</td>
+                    <td class="px-6 py-4 whitespace-nowrap responsive-hide">${statusBadge}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                        <div class="flex gap-4 actions-desktop">
+                            <button data-action="manage-modules" data-client-id="${client.id}" data-client-name="${client.name}" class="btn btn-secondary btn-icon" title="Gerenciar Módulos"><i class="fas fa-cog"></i></button>
+                            <button data-action="edit-client" data-client-id="${client.id}" class="btn btn-secondary btn-icon" title="Editar Cliente"><i class="fas fa-pencil-alt"></i></button>
+                            ${linkButton}
+                        </div>
+                        <a href="client-details.html?clientId=${client.id}&from=admin" class="btn btn-secondary details-mobile">+ detalhes</a>
                     </td>`;
                 adminClientsList.appendChild(row);
             });

--- a/public/js/pages/operador-dashboard.js
+++ b/public/js/pages/operador-dashboard.js
@@ -8,6 +8,7 @@ import {
   where
 } from "https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js";
 import { initTaskDetail, openTaskDetail, hideTaskDetail } from '../ui/task-detail.js';
+import { openTaskModal } from '../ui/task-modal.js';
 
 let state = {
   farmClientId: null,
@@ -174,6 +175,9 @@ function bindUI() {
     window.taskOriginHash = window.location.hash.slice(1);
     openTaskDetail(null, { mode: 'create' });
     window.location.hash = 'task/new';
+  });
+  document.querySelector('[data-action="open-task-modal"]')?.addEventListener('click', () => {
+    openTaskModal(null, 'dashboard');
   });
 }
 

--- a/public/operador-dashboard.html
+++ b/public/operador-dashboard.html
@@ -113,6 +113,7 @@
         <div id="card-7dias-empty" class="hidden flex flex-col items-center justify-center gap-2 text-center text-gray-500 text-[13px] w-full h-[280px] sm:h-[300px]">
           <i class="fas fa-calendar-check text-xl"></i>
           <span>Nada vencendo nos próximos 7 dias</span>
+          <button class="btn btn-primary mt-2" data-action="open-task-modal">Adicionar tarefa</button>
         </div>
         <div id="card-7dias-chart" class="flex items-center justify-center w-full h-[280px] sm:h-[300px] max-w-full">
           <canvas id="chart-7dias" class="w-full h-full hidden cursor-pointer" data-test="chart-7dias"></canvas>

--- a/public/style.css
+++ b/public/style.css
@@ -88,6 +88,11 @@
 @media (max-width:480px){.tasks-table td:last-child .btn{width:100%;height:44px;}}
 
 .btn{min-height:44px;}
+.btn-primary{background-color:var(--brand-600);color:#fff;}
+.btn-primary:hover{background-color:var(--brand-700);}
+.btn-secondary{background-color:#E5E7EB;color:#374151;}
+.btn-secondary:hover{background-color:#D1D5DB;}
+.btn-icon{width:32px;height:32px;padding:0;display:flex;align-items:center;justify-content:center;}
 .select,.input{height:var(--input-h);}
 .details-btn{white-space:nowrap;}
 
@@ -482,15 +487,13 @@ button:active, .btn:active {
 }
 
 .dashboard-container {
-    max-width: 1240px;
-    margin: 0 auto;
-    padding: 1rem;
+    max-width:1240px;
+    margin:0 auto;
+    padding:var(--pad);
 }
 
-@media (min-width: 640px) {
-    .dashboard-container {
-        padding: 1.5rem;
-    }
+@media (min-width:768px){
+    .dashboard-container{padding:var(--pad-lg);}
 }
 
 @media (max-width: 1023px) {
@@ -510,14 +513,17 @@ button:active, .btn:active {
     }
 }
 
-.dashboard-card {
-    background-color: #FFFFFF;
-    border: 1px solid #E5E7EB;
-    border-radius: 0.75rem; /* 12px */
-    padding: 1.25rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
-    box-sizing: border-box;
-    max-width: 100%;
+.dashboard-card{
+    background-color:#FFFFFF;
+    border:1px solid #E5E7EB;
+    border-radius:0.75rem;
+    padding:var(--pad);
+    box-shadow:0 2px 8px rgba(0,0,0,0.06);
+    box-sizing:border-box;
+    max-width:100%;
+}
+@media(min-width:768px){
+    .dashboard-card{padding:var(--pad-lg);}
 }
 
 .kpi-grid .dashboard-card {
@@ -1038,3 +1044,19 @@ body.has-modal{overflow:hidden;}
 .kpi-card .kpi-text{display:flex;flex-direction:column;gap:2px;}
 .kpi-card .kpi-title{font-size:12px;color:#6B7280;}
 .kpi-card .kpi-value{font-weight:700;font-size:24px;line-height:1;}
+/* Dashboard table spacing */
+.dashboard-table th,.dashboard-table td{padding:var(--pad);}
+@media(min-width:768px){.dashboard-table th,.dashboard-table td{padding:var(--pad-lg);}}
+
+/* Responsive table behaviour */
+@media(max-width:767px){
+  .responsive-hide{display:none;}
+  .actions-desktop{display:none;}
+  .details-mobile{display:inline-flex;}
+}
+@media(min-width:768px){
+  .details-mobile{display:none;}
+}
+
+/* Empty state component */
+.empty-state{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;text-align:center;padding:var(--pad);}


### PR DESCRIPTION
## Summary
- add primary and secondary button styles
- unify dashboard spacing and responsive tables
- show actionable empty states with modal hooks

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5afa32eb4832ebcb1bb1cf70d5495