### PR TITLE
feat: add upcoming commitments panel

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -20,6 +20,21 @@
   <main id="agroMain" class="pb-16">
     <section id="view-home" data-view>
       <h2 class="p-4 font-semibold">Home</h2>
+      <div id="agendaHome" class="p-4">
+        <div class="flex items-center justify-between mb-2">
+          <h3 class="font-semibold">Próximos compromissos</h3>
+          <select id="agendaPeriod" class="input w-32">
+            <option value="7">7 dias</option>
+            <option value="30">30 dias</option>
+            <option value="90">90 dias</option>
+          </select>
+        </div>
+        <ul id="agendaList" class="divide-y"></ul>
+        <div id="agendaEmpty" class="empty-state hidden">
+          <p>Nenhum compromisso futuro.</p>
+          <button id="btnAgendaAddVisit" class="btn-primary">Registrar visita</button>
+        </div>
+      </div>
     </section>
     <section id="view-clientes" data-view class="hidden">
       <h2 class="p-4 font-semibold">Clientes</h2>

--- a/public/js/stores/agendaStore.js
+++ b/public/js/stores/agendaStore.js
@@ -14,3 +14,18 @@ export function addAgenda(item) {
   localStorage.setItem(KEY, JSON.stringify(agenda));
   return newItem;
 }
+
+export function updateAgenda(id, changes) {
+  const agenda = getAgenda();
+  const idx = agenda.findIndex((a) => a.id === id);
+  if (idx >= 0) {
+    agenda[idx] = {
+      ...agenda[idx],
+      ...changes,
+      updatedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(KEY, JSON.stringify(agenda));
+    return agenda[idx];
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add "Próximos compromissos" section to agronomist home with period filter and actions
- support marking agenda items as done and show badge on home nav
- include update function in agenda store

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f995e3ec832ea9f3fb372633ce7a