### PR TITLE
Add map layer filters, client highlighting and form validations

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -53,7 +53,12 @@
       </div>
     </section>
     <section id="view-mapa" data-view class="hidden">
-      <div id="agroMap" style="height: calc(100vh - 140px)"></div>
+      <div id="mapFilters" class="p-4 flex gap-2">
+        <button id="mapFilterAll" class="chip chip--filter filter-active">Todos</button>
+        <button id="mapFilterClients" class="chip chip--filter">Clientes</button>
+        <button id="mapFilterLeads" class="chip chip--filter">Leads</button>
+      </div>
+      <div id="agroMap" style="height: calc(100vh - 196px)"></div>
     </section>
     <section id="view-ajustes" data-view class="hidden">
       <h2 class="p-4 font-semibold">Ajustes</h2>

--- a/public/js/pages/agro-map.js
+++ b/public/js/pages/agro-map.js
@@ -1,5 +1,6 @@
 let map;
 let leadsLayer;
+let clientsLayer;
 
 export function initAgroMap() {
   const el = document.getElementById('agroMap');
@@ -13,6 +14,7 @@ export function initAgroMap() {
     maxZoom: 19
   }).addTo(map);
   leadsLayer = L.layerGroup().addTo(map);
+  clientsLayer = L.layerGroup().addTo(map);
   return map;
 }
 
@@ -23,8 +25,39 @@ export function setMapCenter(lat, lng, zoom=14) {
 export function plotLeads(leads) {
   if (!map || typeof L === 'undefined' || !leadsLayer) return;
   leadsLayer.clearLayers();
-  leads.filter(l => l.lat && l.lng).forEach(l => {
-    const marker = L.marker([l.lat, l.lng], { title: l.name || 'Lead' }).addTo(leadsLayer);
-    marker.bindPopup(`<b>${l.name || 'Lead'}</b><br>${l.farmName || ''}`);
-  });
+  leads
+    .filter((l) => l.stage !== 'Convertido' && l.lat && l.lng)
+    .forEach((l) => {
+      const marker = L.marker([l.lat, l.lng], {
+        title: l.name || 'Lead',
+      }).addTo(leadsLayer);
+      marker.bindPopup(`<b>${l.name || 'Lead'}</b><br>${l.farmName || ''}`);
+    });
+}
+
+export function plotClients(clients) {
+  if (!map || typeof L === 'undefined' || !clientsLayer) return;
+  clientsLayer.clearLayers();
+  clients
+    .filter((c) => c.lat && c.lng)
+    .forEach((c) => {
+      const marker = L.marker([c.lat, c.lng], {
+        title: c.name || 'Cliente',
+      }).addTo(clientsLayer);
+      marker.bindPopup(
+        `<b>${c.name || 'Cliente'}</b><br>${c.farmName || ''}`
+      );
+    });
+}
+
+export function setVisibleLayers({ showLeads, showClients }) {
+  if (!map) return;
+  if (leadsLayer) {
+    if (showLeads) map.addLayer(leadsLayer);
+    else map.removeLayer(leadsLayer);
+  }
+  if (clientsLayer) {
+    if (showClients) map.addLayer(clientsLayer);
+    else map.removeLayer(clientsLayer);
+  }
 }


### PR DESCRIPTION
## Summary
- Add client layer and map filters to toggle Leads and Clientes markers
- Highlight newly created clients and enable direct navigation to client details
- Add form validation messages for lead, quick create, visit and sale forms

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a60b1f916c832ebb64cfb9941c2d6a