### PR TITLE
feat: add client sales tracking and details page

### DIFF
--- a/public/client-details.html
+++ b/public/client-details.html
@@ -4,45 +4,112 @@
   <meta name="theme-color" content="#166534">
   <link rel="icon" type="image/png" href="/favicon.png">
   <link rel="manifest" href="/manifest.json">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orgânia - Detalhes do Cliente</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orgânia - Detalhes do Cliente</title>
   <script type="module" src="js/app.js"></script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-gray-100">
-    
-    <div id="client-details-marker" class="hidden"></div>
-
- <header class="bg-white shadow-lg sticky top-0 z-20">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                        <div class="flex justify-between items-center h-16">
-                <div class="flex items-center gap-4">
-                    <a id="backBtn" class="text-gray-500 hover:text-gray-800" title="Voltar">
-                        <i class="fas fa-arrow-left"></i>
-                    </a>
-                    <h1 id="clientNameHeader" class="text-2xl font-bold" style="color: var(--brand-green);">Carregando...</h1>
-                </div>
-                <button onclick="logout()" class="px-4 py-2 bg-red-600 text-white font-bold rounded-lg hover:bg-red-700 text-sm">Sair</button>
-            </div>
+  <header class="bg-white shadow-lg sticky top-0 z-20">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between items-center h-16">
+        <div class="flex items-center gap-4">
+          <a id="backBtn" class="text-gray-500 hover:text-gray-800" title="Voltar"><i class="fas fa-arrow-left"></i></a>
+          <h1 id="clientNameHeader" class="text-2xl font-bold" style="color: var(--brand-green);">Carregando...</h1>
         </div>
-    </header>
- <main class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
-        <div class="bg-white rounded-lg shadow p-6">
-            <div class="flex justify-between items-center mb-4">
-                                <h2 class="text-xl font-bold text-gray-800">Propriedades</h2>
-  <button id="showAddPropertyBtn" class="px-3 py-2 text-white rounded" style="background-color: var(--brand-green);">Adicionar</button>        
+        <button onclick="logout()" class="px-4 py-2 bg-red-600 text-white font-bold rounded-lg hover:bg-red-700 text-sm">Sair</button>
+      </div>
     </div>
-            <div id="propertiesList" class="space-y-2"></div>
-        </div>
-    </main>
+  </header>
 
-    <script src="/__/firebase/9.6.1/firebase-app-compat.js"></script>
-    <script src="/__/firebase/9.6.1/firebase-auth-compat.js"></script>
-    <script src="/__/firebase/9.6.1/firebase-firestore-compat.js"></script>
-    <script src="/__/firebase/init.js"></script>
-    <script type="module" src="js/services/auth.js"></script>
+  <main class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8 space-y-6">
+    <section class="bg-white rounded-lg shadow p-6">
+      <h2 class="text-xl font-bold mb-4">Resumo</h2>
+      <div class="space-y-1">
+        <div id="summaryName" class="font-semibold"></div>
+        <div id="summaryProperty" class="text-sm text-gray-600"></div>
+      </div>
+      <button id="btnViewMap" class="btn-secondary mt-4">Ver no mapa</button>
+    </section>
+
+    <section class="bg-white rounded-lg shadow p-6">
+      <div class="flex justify-between items-center mb-4">
+        <h2 class="text-xl font-bold text-gray-800">Propriedades</h2>
+        <button id="showAddPropertyBtn" class="px-3 py-2 text-white rounded" style="background-color: var(--brand-green);">Adicionar</button>
+      </div>
+      <div id="propertiesList" class="space-y-2"></div>
+    </section>
+
+    <section class="bg-white rounded-lg shadow p-6">
+      <div class="flex justify-between items-center mb-4">
+        <h2 class="text-xl font-bold text-gray-800">Histórico</h2>
+        <div class="flex gap-2">
+          <button id="btnRegisterVisit" class="btn-secondary text-sm">Registrar visita</button>
+          <button id="btnNewSale" class="btn-primary text-sm">Nova venda</button>
+        </div>
+      </div>
+      <div id="historyTimeline"></div>
+    </section>
+  </main>
+
+  <!-- Add Property Modal -->
+  <div id="addPropertyModal" class="modal hidden">
+    <div class="modal-card w-full max-w-md">
+      <h3 class="font-semibold mb-4">Adicionar Propriedade</h3>
+      <form id="addPropertyForm" class="grid gap-4">
+        <div class="field">
+          <label for="addPropName">Nome*</label>
+          <input id="addPropName" class="input" required />
+        </div>
+        <div class="field">
+          <label>Localização</label>
+          <button type="button" id="addPropUseLocation" class="btn-secondary mb-2">Usar minha localização</button>
+          <div class="flex gap-2">
+            <input id="addPropLat" class="input flex-1" placeholder="Lat" readonly />
+            <input id="addPropLng" class="input flex-1" placeholder="Lng" readonly />
+          </div>
+        </div>
+        <div class="flex gap-2 justify-end">
+          <button type="button" id="btnAddPropCancel" class="btn-secondary">Cancelar</button>
+          <button type="submit" class="btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Sale Modal -->
+  <div id="saleModal" class="modal hidden">
+    <div class="modal-card max-w-md w-full">
+      <h3 class="mb-4 font-semibold">Registrar Venda</h3>
+      <form id="saleForm" class="grid gap-4">
+        <div class="field">
+          <label for="saleFormula">Fórmula</label>
+          <select id="saleFormula" class="input"></select>
+        </div>
+        <div class="field">
+          <label for="saleTons">Toneladas</label>
+          <input id="saleTons" type="number" min="0.1" step="0.1" class="input" required />
+        </div>
+        <div class="field">
+          <label for="saleNote">Observação</label>
+          <textarea id="saleNote" class="input"></textarea>
+        </div>
+        <div class="flex gap-2 justify-end">
+          <button type="button" id="btnSaleCancel" class="btn-secondary">Cancelar</button>
+          <button type="submit" class="btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script src="/__/firebase/9.6.1/firebase-app-compat.js"></script>
+  <script src="/__/firebase/9.6.1/firebase-auth-compat.js"></script>
+  <script src="/__/firebase/9.6.1/firebase-firestore-compat.js"></script>
+  <script src="/__/firebase/init.js"></script>
+  <script type="module" src="js/services/auth.js"></script>
+  <script type="module" src="js/pages/client-details.js"></script>
 </body>
 </html>

--- a/public/js/pages/agro-map.js
+++ b/public/js/pages/agro-map.js
@@ -1,6 +1,7 @@
 let map;
 let leadsLayer;
 let clientsLayer;
+let clientMarkers = {};
 
 export function initAgroMap() {
   const el = document.getElementById('agroMap');
@@ -38,6 +39,7 @@ export function plotLeads(leads) {
 export function plotClients(clients) {
   if (!map || typeof L === 'undefined' || !clientsLayer) return;
   clientsLayer.clearLayers();
+  clientMarkers = {};
   clients
     .filter((c) => c.lat && c.lng)
     .forEach((c) => {
@@ -45,9 +47,19 @@ export function plotClients(clients) {
         title: c.name || 'Cliente',
       }).addTo(clientsLayer);
       marker.bindPopup(
-        `<b>${c.name || 'Cliente'}</b><br>${c.farmName || ''}`
+        `<b>${c.name || 'Cliente'}</b><br>${c.farmName || ''}<br><a href="client-details.html?clientId=${c.id}">Abrir cliente</a>`
       );
+      clientMarkers[c.id] = marker;
     });
+}
+
+export function focusClient(id) {
+  const m = clientMarkers[id];
+  if (m) {
+    const pos = m.getLatLng();
+    setMapCenter(pos.lat, pos.lng);
+    m.openPopup();
+  }
 }
 
 export function setVisibleLayers({ showLeads, showClients }) {

--- a/public/js/pages/client-details.js
+++ b/public/js/pages/client-details.js
@@ -1,60 +1,231 @@
-import { db } from '../config/firebase.js';
-import { doc, getDoc, collection, getDocs, addDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+import { getClients } from '../stores/clientsStore.js';
+import { getProperties, addProperty } from '../stores/propertiesStore.js';
+import { getVisits } from '../stores/visitsStore.js';
+import { getSalesByClient, addSale } from '../stores/salesStore.js';
+import { getCurrentPositionSafe } from '../utils/geo.js';
 
-export async function initClientDetails(userId, userRole) {
-        const params = new URLSearchParams(window.location.search);
-    const clientId = params.get('clientId');
-    const from = params.get('from') || 'agronomo';
-
-    const backBtn = document.getElementById('backBtn');
- const clientNameHeader = document.getElementById('clientNameHeader');
-     const propertiesListDiv = document.getElementById('propertiesList');
- const showAddPropertyBtn = document.getElementById('showAddPropertyBtn');
-
-   if (backBtn) {
-        backBtn.href = from === 'admin' ? 'dashboard-admin.html' : 'dashboard-agronomo.html';
-    }
-
-    if (!clientId) {
- clientNameHeader.textContent = 'Cliente não encontrado';
-         return;
-    }
-
-const clientRef = doc(db, 'clients', clientId);
-    const clientSnap = await getDoc(clientRef);
-    if (clientSnap.exists()) {
-        clientNameHeader.textContent = clientSnap.data().name || 'Cliente';
-        }
-
- async function loadProperties() {
-        propertiesListDiv.innerHTML = '';
-        const propsSnap = await getDocs(collection(clientRef, 'properties'));
-        if (propsSnap.empty) {
-            propertiesListDiv.innerHTML = '<p class="text-gray-500">Nenhuma propriedade cadastrada.</p>';
-                        return;
-        }
-propsSnap.forEach(propDoc => {
-            const prop = propDoc.data();
-            const div = document.createElement('div');
-            div.className = 'p-4 border rounded cursor-pointer hover:bg-gray-50';
-            div.textContent = prop.name || 'Propriedade';
-            div.addEventListener('click', () => {
-                window.location.href = `property-details.html?clientId=${clientId}&propertyId=${propDoc.id}&from=${from}`;
-            });
-propertiesListDiv.appendChild(div);
-        });
-    }
-
-async function addProperty() {
-        const name = prompt('Nome da propriedade');
-        if (!name) return;
-        await addDoc(collection(clientRef, 'properties'), { name });
-        loadProperties();
-    }
-
-    if (showAddPropertyBtn) {
-        showAddPropertyBtn.addEventListener('click', addProperty);
-    }
-
-    loadProperties();
+function toggleModal(modal, show) {
+  if (!modal) return;
+  modal.classList.toggle('hidden', !show);
+  document.body.classList.toggle('has-modal', show);
 }
+
+function clearErrors(form) {
+  form?.querySelectorAll('.error').forEach((e) => e.remove());
+}
+function setFieldError(input, message) {
+  const field = input.closest('.field') || input.parentElement;
+  if (!field) return;
+  let span = field.querySelector('span.error');
+  if (!span) {
+    span = document.createElement('span');
+    span.className = 'error';
+    field.appendChild(span);
+  }
+  span.textContent = message;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(location.search);
+  const clientId = params.get('clientId');
+  if (!clientId) return;
+
+  const client = getClients().find((c) => c.id === clientId);
+  const clientNameHeader = document.getElementById('clientNameHeader');
+  if (clientNameHeader) clientNameHeader.textContent = client?.name || 'Cliente';
+
+  document.getElementById('backBtn')?.addEventListener('click', () => history.back());
+
+  const summaryName = document.getElementById('summaryName');
+  const summaryProperty = document.getElementById('summaryProperty');
+  if (summaryName) summaryName.textContent = client?.name || '';
+  const allProps = getProperties().filter((p) => p.clientId === clientId);
+  const mainProp = allProps[0];
+  if (summaryProperty) {
+    if (mainProp) {
+      const loc = [];
+      if (mainProp.city) loc.push(mainProp.city);
+      if (mainProp.state) loc.push(mainProp.state);
+      summaryProperty.textContent = `${mainProp.name}${loc.length ? ' - ' + loc.join('/') : ''}`;
+    } else summaryProperty.textContent = '—';
+  }
+
+  document.getElementById('btnViewMap')?.addEventListener('click', () => {
+    sessionStorage.setItem('focusClientId', clientId);
+    location.href = 'dashboard-agronomo.html#mapa';
+  });
+
+  const propertiesListDiv = document.getElementById('propertiesList');
+  function renderProperties() {
+    propertiesListDiv.innerHTML = '';
+    const props = getProperties().filter((p) => p.clientId === clientId);
+    if (!props.length) {
+      propertiesListDiv.innerHTML = '<p class="text-gray-500">Nenhuma propriedade cadastrada.</p>';
+      return;
+    }
+    props.forEach((p) => {
+      const div = document.createElement('div');
+      div.className = 'card';
+      div.textContent = p.name;
+      propertiesListDiv.appendChild(div);
+    });
+  }
+  renderProperties();
+
+  const addModal = document.getElementById('addPropertyModal');
+  const addForm = document.getElementById('addPropertyForm');
+  document.getElementById('showAddPropertyBtn')?.addEventListener('click', () => {
+    addForm.reset();
+    clearErrors(addForm);
+    toggleModal(addModal, true);
+  });
+  document.getElementById('addPropUseLocation')?.addEventListener('click', async () => {
+    const coords = await getCurrentPositionSafe();
+    if (coords) {
+      document.getElementById('addPropLat').value = coords.lat.toFixed(6);
+      document.getElementById('addPropLng').value = coords.lng.toFixed(6);
+    }
+  });
+  document.getElementById('btnAddPropCancel')?.addEventListener('click', () => toggleModal(addModal, false));
+  addForm?.addEventListener('submit', (ev) => {
+    ev.preventDefault();
+    clearErrors(addForm);
+    const nameInput = document.getElementById('addPropName');
+    const name = nameInput.value.trim();
+    if (!name) {
+      setFieldError(nameInput, 'Campo obrigatório');
+      return;
+    }
+    const lat = parseFloat(document.getElementById('addPropLat').value);
+    const lng = parseFloat(document.getElementById('addPropLng').value);
+    const prop = { clientId, name };
+    if (!isNaN(lat) && !isNaN(lng)) Object.assign(prop, { lat, lng });
+    addProperty(prop);
+    toggleModal(addModal, false);
+    renderProperties();
+  });
+
+  function renderTimeline() {
+    const container = document.getElementById('historyTimeline');
+    container.innerHTML = '';
+    const visits = getVisits().filter((v) => v.type === 'cliente' && v.refId === clientId);
+    const sales = getSalesByClient(clientId);
+    const items = [
+      ...visits.map((v) => ({ type: 'visit', at: v.at, note: v.note })),
+      ...sales.map((s) => ({
+        type: 'sale',
+        at: s.createdAt,
+        formulationName: s.formulationName || s.formulationId,
+        tons: s.tons,
+        note: s.note,
+      })),
+    ].sort((a, b) => new Date(b.at) - new Date(a.at));
+    if (!items.length) {
+      container.innerHTML = '<p class="text-gray-500">Sem histórico.</p>';
+      return;
+    }
+    const ul = document.createElement('ul');
+    ul.className = 'timeline';
+    items.forEach((it) => {
+      const li = document.createElement('li');
+      li.className = 'timeline-item';
+      const badge = document.createElement('span');
+      badge.className = 'timeline-badge';
+      const card = document.createElement('div');
+      card.className = 'card ml-4';
+      const dateStr = new Date(it.at).toLocaleString('pt-BR');
+      if (it.type === 'visit') {
+        card.innerHTML = `<div class="font-semibold">Visita</div><div class="text-sm text-gray-500">${dateStr}</div><div>${it.note || ''}</div>`;
+      } else {
+        card.innerHTML = `<div class="font-semibold">Venda</div><div class="text-sm text-gray-500">${dateStr}</div><div>${it.formulationName} - ${it.tons}t</div><div>${it.note || ''}</div>`;
+      }
+      li.appendChild(badge);
+      li.appendChild(card);
+      ul.appendChild(li);
+    });
+    container.appendChild(ul);
+  }
+  renderTimeline();
+
+  document.getElementById('btnRegisterVisit')?.addEventListener('click', () => {
+    sessionStorage.setItem('visitForClientId', clientId);
+    location.href = 'dashboard-agronomo.html#visita';
+  });
+
+  document.getElementById('btnNewSale')?.addEventListener('click', async () => {
+    const data = await openSaleModal();
+    if (!data) return;
+    addSale({ clientId, ...data });
+    renderTimeline();
+  });
+
+  async function openSaleModal() {
+    const modal = document.getElementById('saleModal');
+    const saleForm = document.getElementById('saleForm');
+    const formulaSelect = document.getElementById('saleFormula');
+    await loadFormulas();
+    toggleModal(modal, true);
+    return new Promise((resolve) => {
+      function cleanup() {
+        saleForm.removeEventListener('submit', onSubmit);
+        document.getElementById('btnSaleCancel').removeEventListener('click', onCancel);
+      }
+      function onSubmit(e) {
+        e.preventDefault();
+        clearErrors(saleForm);
+        const formulationId = formulaSelect.value;
+        const formulationName = formulaSelect.options[formulaSelect.selectedIndex]?.textContent || '';
+        const tonsEl = document.getElementById('saleTons');
+        const tons = parseFloat(tonsEl.value);
+        let valid = true;
+        if (!formulationId) {
+          setFieldError(formulaSelect, 'Campo obrigatório');
+          valid = false;
+        }
+        if (!tons || tons <= 0) {
+          setFieldError(tonsEl, 'Campo obrigatório');
+          valid = false;
+        }
+        if (!valid) return;
+        const note = document.getElementById('saleNote').value.trim();
+        toggleModal(modal, false);
+        saleForm.reset();
+        cleanup();
+        resolve({ formulationId, formulationName, tons, note });
+      }
+      function onCancel() {
+        toggleModal(modal, false);
+        saleForm.reset();
+        cleanup();
+        resolve(null);
+      }
+      saleForm.addEventListener('submit', onSubmit);
+      document.getElementById('btnSaleCancel').addEventListener('click', onCancel);
+    });
+  }
+
+  async function loadFormulas() {
+    const sel = document.getElementById('saleFormula');
+    sel.innerHTML = '';
+    let formulas = [];
+    try {
+      const snap = await firebase
+        .firestore()
+        .collection('fertilizer_formulas')
+        .where('isFixed', '==', true)
+        .get();
+      formulas = snap.docs.map((d) => ({ id: d.id, name: d.data().name }));
+    } catch (e) {
+      formulas = [
+        { id: 'local1', name: 'Fórmula A' },
+        { id: 'local2', name: 'Fórmula B' },
+      ];
+    }
+    formulas.forEach((f) => {
+      const opt = document.createElement('option');
+      opt.value = f.id;
+      opt.textContent = f.name;
+      sel.appendChild(opt);
+    });
+  }
+});

--- a/public/js/stores/salesStore.js
+++ b/public/js/stores/salesStore.js
@@ -1,0 +1,22 @@
+const KEY = 'agro.sales';
+
+export function getSales() {
+  return JSON.parse(localStorage.getItem(KEY) || '[]');
+}
+
+export function addSale(sale) {
+  const sales = getSales();
+  const now = new Date().toISOString();
+  const newSale = {
+    id: Date.now().toString(36),
+    createdAt: now,
+    ...sale,
+  };
+  sales.push(newSale);
+  localStorage.setItem(KEY, JSON.stringify(sales));
+  return newSale;
+}
+
+export function getSalesByClient(clientId) {
+  return getSales().filter((s) => s.clientId === clientId);
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1118,3 +1118,10 @@ body.has-modal{overflow:hidden;}
 @media (min-width:768px){
   .modal-card{max-width:600px;}
 }
+
+/* Timeline components */
+.timeline{position:relative;margin-left:1rem;}
+.timeline::before{content:"";position:absolute;top:0;bottom:0;left:-0.5rem;width:2px;background:#E5E7EB;}
+.timeline-item{position:relative;margin-bottom:1rem;}
+.timeline-badge{position:absolute;left:-0.75rem;top:0.25rem;width:0.5rem;height:0.5rem;border-radius:50%;background:var(--brand-green);}
+.card{background:#fff;border:1px solid #E5E7EB;border-radius:8px;padding:1rem;}


### PR DESCRIPTION
## Summary
- add localStorage sales store and integrate sales recording when converting leads
- introduce client details page with properties, timeline, and quick actions
- enhance map markers with client links and focus behavior

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a613b50128832ebfa0cd27a7c43bb1