### PR TITLE
chore: include origin info in agronomist navigation

### DIFF
--- a/public/js/pages/agro-map.js
+++ b/public/js/pages/agro-map.js
@@ -47,7 +47,7 @@ export function plotClients(clients) {
         title: c.name || 'Cliente',
       }).addTo(clientsLayer);
       marker.bindPopup(
-        `<b>${c.name || 'Cliente'}</b><br>${c.farmName || ''}<br><a href="client-details.html?clientId=${c.id}">Abrir cliente</a>`
+        `<b>${c.name || 'Cliente'}</b><br>${c.farmName || ''}<br><a href="client-details.html?clientId=${c.id}&from=agronomo">Abrir cliente</a>`
       );
       clientMarkers[c.id] = marker;
     });

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -298,7 +298,7 @@ export function initAgronomoDashboard() {
       btnOpen.className = 'btn-secondary text-sm flex-1';
       btnOpen.textContent = 'Abrir';
       btnOpen.addEventListener('click', () => {
-        location.href = `client-details.html?clientId=${it.client.id}`;
+        location.href = `client-details.html?clientId=${it.client.id}&from=agronomo`;
       });
       actions.appendChild(btnVisit);
       actions.appendChild(btnOpen);


### PR DESCRIPTION
## Summary
- ensure agronomist client cards route with source information
- include origin parameter when opening clients from map popup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f64ff51c832eb7f6762ca5eab61c