### PR TITLE
feat: add home metrics and quick actions

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -20,6 +20,28 @@
   <main id="agroMain" class="pb-16">
     <section id="view-home" data-view>
       <h2 class="p-4 font-semibold">Home</h2>
+      <div id="homeMetrics" class="p-4 grid gap-4 sm:grid-cols-3">
+        <div class="bg-white p-4 rounded shadow text-center">
+          <div class="text-sm text-gray-500">Clientes ativos</div>
+          <div id="metricClients" class="text-2xl font-bold">0</div>
+          <div class="text-xs text-gray-600">total</div>
+        </div>
+        <div class="bg-white p-4 rounded shadow text-center">
+          <div class="text-sm text-gray-500">Visitas</div>
+          <div id="metricVisits" class="text-2xl font-bold">0</div>
+          <div class="text-xs text-gray-600">últimos 30 dias</div>
+        </div>
+        <div class="bg-white p-4 rounded shadow text-center">
+          <div class="text-sm text-gray-500">Vendas (t)</div>
+          <div id="metricSales" class="text-2xl font-bold">0</div>
+          <div class="text-xs text-gray-600">últimos 30 dias</div>
+        </div>
+      </div>
+      <div id="homeQuickActions" class="px-4 flex gap-2">
+        <button id="chipAddCliente" class="chip">Adicionar cliente</button>
+        <button id="chipAddLead" class="chip">Adicionar lead</button>
+        <button id="chipRegVisit" class="chip">Registrar visita</button>
+      </div>
       <div id="agendaHome" class="p-4">
         <div class="flex items-center justify-between mb-2">
           <h3 class="font-semibold">Próximos compromissos</h3>

--- a/public/js/utils/metrics.js
+++ b/public/js/utils/metrics.js
@@ -1,0 +1,22 @@
+import { getVisits } from '../stores/visitsStore.js';
+import { getSales } from '../stores/salesStore.js';
+
+export function countVisitsLast30d() {
+  const visits = getVisits();
+  const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  return visits.filter((v) => {
+    const at = new Date(v.at).getTime();
+    return !isNaN(at) && at >= cutoff;
+  }).length;
+}
+
+export function sumSalesLast30d() {
+  const sales = getSales();
+  const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  return sales
+    .filter((s) => {
+      const at = new Date(s.createdAt).getTime();
+      return !isNaN(at) && at >= cutoff;
+    })
+    .reduce((sum, s) => sum + (parseFloat(s.tons) || 0), 0);
+}


### PR DESCRIPTION
## Summary
- add metric cards and quick action chips to agronomist home
- compute last 30-day visit and sales metrics with shared helpers
- refresh home metrics and agenda after data changes and task completion

## Testing
- `npm install` *(fails: 403 Forbidden - @playwright/test)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ff6dc650832e929e70acb0f87e06