### PR TITLE
feat: add dynamic agronomist map with client and lead markers

### DIFF
--- a/public/js/pages/agro-map.js
+++ b/public/js/pages/agro-map.js
@@ -3,6 +3,32 @@ let leadsLayer;
 let clientsLayer;
 let clientMarkers = {};
 
+// Simple colored icons for leads and clients so each type is easily
+// distinguishable on the map.
+const leadIcon =
+  typeof L !== 'undefined'
+    ? L.divIcon({
+        className: 'lead-marker',
+        html:
+          '<div style="background:#3b82f6;width:16px;height:16px;border-radius:50%;border:2px solid #fff"></div>',
+        iconSize: [16, 16],
+        iconAnchor: [8, 16],
+        popupAnchor: [0, -16],
+      })
+    : null;
+
+const clientIcon =
+  typeof L !== 'undefined'
+    ? L.divIcon({
+        className: 'client-marker',
+        html:
+          '<div style="background:#16a34a;width:16px;height:16px;border-radius:50%;border:2px solid #fff"></div>',
+        iconSize: [16, 16],
+        iconAnchor: [8, 16],
+        popupAnchor: [0, -16],
+      })
+    : null;
+
 export function initAgroMap() {
   const el = document.getElementById('agroMap');
   if (!el) return null;
@@ -31,8 +57,13 @@ export function plotLeads(leads) {
     .forEach((l) => {
       const marker = L.marker([l.lat, l.lng], {
         title: l.name || 'Lead',
+        icon: leadIcon || undefined,
       }).addTo(leadsLayer);
-      marker.bindPopup(`<b>${l.name || 'Lead'}</b><br>${l.farmName || ''}`);
+      const loc = l.farmName || `(${l.lat.toFixed(4)}, ${l.lng.toFixed(4)})`;
+      const interest = l.interest ? `<br>Interesse: ${l.interest}` : '';
+      marker.bindPopup(
+        `<b>${l.name || 'Lead'}</b>${interest}<br>${loc}<br><a href="client-details.html?leadId=${l.id}&from=agronomo">Ver detalhes</a>`
+      );
     });
 }
 
@@ -45,9 +76,11 @@ export function plotClients(clients) {
     .forEach((c) => {
       const marker = L.marker([c.lat, c.lng], {
         title: c.name || 'Cliente',
+        icon: clientIcon || undefined,
       }).addTo(clientsLayer);
+      const loc = c.farmName || `(${c.lat.toFixed(4)}, ${c.lng.toFixed(4)})`;
       marker.bindPopup(
-        `<b>${c.name || 'Cliente'}</b><br>${c.farmName || ''}<br><a href="client-details.html?clientId=${c.id}&from=agronomo">Abrir cliente</a>`
+        `<b>${c.name || 'Cliente'}</b><br>${loc}<br><a href="client-details.html?clientId=${c.id}&from=agronomo">Ver detalhes</a>`
       );
       clientMarkers[c.id] = marker;
     });
@@ -72,4 +105,11 @@ export function setVisibleLayers({ showLeads, showClients }) {
     if (showClients) map.addLayer(clientsLayer);
     else map.removeLayer(clientsLayer);
   }
+}
+
+// Fit map view to an array of [lat, lng] points.
+export function fitMapToPoints(points) {
+  if (!map || typeof L === 'undefined' || !points.length) return;
+  const bounds = L.latLngBounds(points);
+  map.fitBounds(bounds, { padding: [20, 20] });
 }


### PR DESCRIPTION
## Summary
- display clients and leads on agronomist map with color-coded markers and detail links
- auto-center map on available markers or user's location when none

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a70aee94f8832e803b68d34de79407