### PR TITLE
Fix navigation and parameter passing between pages

### DIFF
--- a/public/js/pages/client-details.js
+++ b/public/js/pages/client-details.js
@@ -95,13 +95,11 @@ export function initClientDetails(userId, userRole) {
       return;
     }
     props.forEach((p) => {
-      const div = document.createElement('div');
-      div.className = 'card';
-      div.textContent = p.name;
-      div.addEventListener('click', () => {
-        location.href = `property-details.html?clientId=${clientId}&propertyId=${p.id}&from=${from}`;
-      });
-      propertiesListDiv.appendChild(div);
+      const link = document.createElement('a');
+      link.className = 'card block';
+      link.textContent = p.name;
+      link.href = `property-details.html?clientId=${clientId}&propertyId=${p.id}&from=${from}`;
+      propertiesListDiv.appendChild(link);
     });
   }
   renderProperties();

--- a/public/js/pages/property-details.js
+++ b/public/js/pages/property-details.js
@@ -15,6 +15,7 @@ export function initPropertyDetails(userId, userRole) {
     const backBtn = document.getElementById('backBtn');
     const plotsListDiv = document.getElementById('plotsList');
     const showAddPlotModalBtn = document.getElementById('showAddPlotModalBtn');
+    const viewEmployeesBtn = document.getElementById('viewEmployeesBtn');
   
     const addPlotModal = document.getElementById('addPlotModal');
     const closeAddPlotModalBtn = document.getElementById('closeAddPlotModalBtn');
@@ -28,6 +29,10 @@ export function initPropertyDetails(userId, userRole) {
     if (!currentPropertyId || !currentClientId) {
          if (propertyNameHeader) propertyNameHeader.textContent = 'ID da Propriedade ou do Cliente não encontrado.';
         return;
+    }
+
+    if (viewEmployeesBtn) {
+        viewEmployeesBtn.href = `property-employees.html?clientId=${currentClientId}&propertyId=${currentPropertyId}&from=${from}`;
     }
 
     const propertyDocRef = doc(collection(db, `clients/${currentClientId}/properties`), currentPropertyId);

--- a/public/js/pages/property-employees.js
+++ b/public/js/pages/property-employees.js
@@ -6,9 +6,10 @@ export async function initPropertyEmployees() {
   const params = new URLSearchParams(window.location.search);
   const clientId = params.get('clientId');
   const propertyId = params.get('propertyId');
+  const from = params.get('from') || 'agronomo';
   if (!clientId || !propertyId) return;
 
-  document.getElementById('backToFarm').href = `agronomo-farm.html?clientId=${clientId}&propertyId=${propertyId}`;
+  document.getElementById('backToFarm').href = `property-details.html?clientId=${clientId}&propertyId=${propertyId}&from=${from}`;
 
   try {
     const employeesRef = collection(doc(db, `clients/${clientId}/properties/${propertyId}`), 'employees');

--- a/public/property-details.html
+++ b/public/property-details.html
@@ -31,8 +31,11 @@
     </header>
 
 <main class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8"> <div class="px-4 sm:px-0 mb-6">
-                <h2 id="propertyNameHeader" class="text-3xl font-bold text-gray-800">Carregando...</h2>
+            <h2 id="propertyNameHeader" class="text-3xl font-bold text-gray-800">Carregando...</h2>
             <p id="clientNameDisplay" class="text-md text-gray-500 mt-1">Cliente: </p>
+            <div class="mt-4">
+                <a id="viewEmployeesBtn" class="px-5 py-2 bg-blue-600 text-white font-bold rounded-lg hover:bg-blue-700 text-sm shadow cursor-pointer">Ver Funcionários</a>
+            </div>
         </div>
 
         <div class="space-y-8 px-4 sm:px-0">


### PR DESCRIPTION
## Summary
- ensure client property links navigate with query params
- add employees link in property details and proper back navigation
- preserve client/property context when viewing employees

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a711624140832e9f2eaae931f38b9d