### PR TITLE
fix: handle missing docs when adding plot

### DIFF
--- a/public/js/pages/property-details.js
+++ b/public/js/pages/property-details.js
@@ -74,8 +74,9 @@ export function initPropertyDetails(userId, userRole) {
                 status: 'ativo',
                 createdAt: serverTimestamp()
             });
-            batch.update(clientDocRef, { cultureCount: increment(1) });
-            batch.update(propertyDocRef, { plotCount: increment(1) });
+            // Use set with merge to avoid errors if documents don't exist yet
+            batch.set(clientDocRef, { cultureCount: increment(1) }, { merge: true });
+            batch.set(propertyDocRef, { plotCount: increment(1) }, { merge: true });
             await batch.commit();
 
  newPlotNameInput.value = '';


### PR DESCRIPTION
## Summary
- avoid missing-document errors when incrementing counters for new plots/cultures

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7211b59f4832eb05a678d38226db9