### PR TITLE
feat: style agronomo home dashboard

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -19,95 +19,113 @@
 
   <main id="agroMain" class="pb-16">
     <section id="view-home" data-view>
-      <h2 class="p-4 font-semibold">Home</h2>
+      <h2 class="p-4 text-xl font-bold text-gray-800">Home</h2>
       <div
         id="homeKpis"
-        class="px-4 grid grid-cols-2 gap-4 sm:grid-cols-4"
+        class="px-4 grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4"
       >
-        <div class="bg-white p-4 rounded shadow text-center">
-          <div class="text-sm text-gray-500">Leads</div>
-          <div id="kpiLeadsTotal" class="text-2xl font-bold">0</div>
+        <div class="kpi-card space-y-2">
+          <div class="kpi-icon"><i class="fas fa-user-plus" aria-hidden="true"></i></div>
+          <div id="kpiLeadsTotal" class="kpi-value text-2xl md:text-3xl font-bold text-gray-800"></div>
+          <div class="text-xs text-gray-500">Leads</div>
         </div>
-        <div class="bg-white p-4 rounded shadow text-center">
-          <div class="text-sm text-gray-500">Clientes</div>
-          <div id="kpiClientsTotal" class="text-2xl font-bold">0</div>
+        <div class="kpi-card space-y-2">
+          <div class="kpi-icon"><i class="fas fa-users" aria-hidden="true"></i></div>
+          <div id="kpiClientsTotal" class="kpi-value text-2xl md:text-3xl font-bold text-gray-800"></div>
+          <div class="text-xs text-gray-500">Clientes</div>
         </div>
-        <div class="bg-white p-4 rounded shadow text-center">
-          <div class="text-sm text-gray-500">Visitas (30d)</div>
-          <div id="kpiVisits30d" class="text-2xl font-bold">0</div>
+        <div class="kpi-card space-y-2">
+          <div class="kpi-icon"><i class="fas fa-map-marker-alt" aria-hidden="true"></i></div>
+          <div id="kpiVisits30d" class="kpi-value text-2xl md:text-3xl font-bold text-gray-800"></div>
+          <div class="text-xs text-gray-500">Visitas (30d)</div>
         </div>
-        <div class="bg-white p-4 rounded shadow text-center">
-          <div class="text-sm text-gray-500">Vendas (30d)</div>
-          <div id="kpiSales30d" class="text-2xl font-bold">0</div>
+        <div class="kpi-card space-y-2">
+          <div class="kpi-icon"><i class="fas fa-shopping-cart" aria-hidden="true"></i></div>
+          <div id="kpiSales30d" class="kpi-value text-2xl md:text-3xl font-bold text-gray-800"></div>
+          <div class="text-xs text-gray-500">Vendas (30d)</div>
         </div>
       </div>
       <div
         id="homeShortcuts"
-        class="p-4 grid grid-cols-2 gap-4 md:grid-cols-4"
+        class="p-4 grid grid-cols-2 sm:grid-cols-3 gap-3"
       >
         <button
           id="quickHomeAddLead"
-          class="p-4 bg-white rounded shadow flex flex-col items-center justify-center hover:bg-gray-50"
+          aria-label="Adicionar Lead"
+          class="chip-action w-full"
         >
-          <i class="fas fa-user-plus text-lg"></i>
-          <span class="text-xs mt-1">Adicionar Lead</span>
+          <i class="fas fa-user-plus text-emerald-700" aria-hidden="true"></i>
+          <span class="text-sm text-gray-600">Adicionar Lead</span>
         </button>
         <button
           id="quickHomeAddClient"
-          class="p-4 bg-white rounded shadow flex flex-col items-center justify-center hover:bg-gray-50"
+          aria-label="Adicionar Cliente"
+          class="chip-action w-full"
         >
-          <i class="fas fa-user text-lg"></i>
-          <span class="text-xs mt-1">Adicionar Cliente</span>
+          <i class="fas fa-user text-emerald-700" aria-hidden="true"></i>
+          <span class="text-sm text-gray-600">Adicionar Cliente</span>
         </button>
         <button
           id="quickHomeAddVisit"
-          class="p-4 bg-white rounded shadow flex flex-col items-center justify-center hover:bg-gray-50"
+          aria-label="Registrar Visita"
+          class="chip-action w-full"
         >
-          <i class="fas fa-map-marker-alt text-lg"></i>
-          <span class="text-xs mt-1">Registrar Visita</span>
+          <i class="fas fa-map-marker-alt text-emerald-700" aria-hidden="true"></i>
+          <span class="text-sm text-gray-600">Registrar Visita</span>
         </button>
         <button
           id="quickHomeOpenMap"
-          class="p-4 bg-white rounded shadow flex flex-col items-center justify-center hover:bg-gray-50"
+          aria-label="Abrir Mapa"
+          class="chip-action w-full"
         >
-          <i class="fas fa-map text-lg"></i>
-          <span class="text-xs mt-1">Abrir Mapa</span>
+          <i class="fas fa-map text-emerald-700" aria-hidden="true"></i>
+          <span class="text-sm text-gray-600">Abrir Mapa</span>
         </button>
         <button
           id="quickHomeOpenClients"
-          class="p-4 bg-white rounded shadow flex flex-col items-center justify-center hover:bg-gray-50"
+          aria-label="Abrir Clientes"
+          class="chip-action w-full"
         >
-          <i class="fas fa-users text-lg"></i>
-          <span class="text-xs mt-1">Abrir Clientes</span>
+          <i class="fas fa-users text-emerald-700" aria-hidden="true"></i>
+          <span class="text-sm text-gray-600">Abrir Clientes</span>
         </button>
         <button
           id="quickHomeGotoAgenda"
-          class="p-4 bg-white rounded shadow flex flex-col items-center justify-center hover:bg-gray-50"
+          aria-label="Agenda (7d)"
+          class="chip-action w-full"
         >
-          <i class="fas fa-calendar-alt text-lg"></i>
-          <span class="text-xs mt-1">Agenda (7d)</span>
+          <i class="fas fa-calendar-alt text-emerald-700" aria-hidden="true"></i>
+          <span class="text-sm text-gray-600">Agenda (7d)</span>
         </button>
       </div>
-      <div id="homeCharts" class="p-4 grid gap-4 md:grid-cols-2">
-        <div class="bg-white p-4 rounded shadow">
-          <canvas id="chartVisits30d"></canvas>
+      <div id="homeCharts" class="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="card-soft min-w-0">
+          <h4 class="text-sm font-semibold text-gray-800 mb-2">Visitas nos últimos 30 dias</h4>
+          <canvas id="chartVisits30d" class="h-64 md:h-72"></canvas>
+          <div class="text-xs text-gray-500 mt-2 text-center">Últimos 30 dias</div>
         </div>
-        <div class="bg-white p-4 rounded shadow">
-          <canvas id="chartSalesByFormula"></canvas>
+        <div class="card-soft min-w-0">
+          <h4 class="text-sm font-semibold text-gray-800 mb-2">Vendas por fórmula (90d)</h4>
+          <canvas id="chartSalesByFormula" class="h-64 md:h-72"></canvas>
+          <div class="text-xs text-gray-500 mt-2 text-center">Últimos 90 dias</div>
         </div>
       </div>
       <div id="agendaHome" class="p-4">
         <div class="flex items-center justify-between mb-2">
-          <h3 class="font-semibold">Próximos compromissos</h3>
+          <h3 class="text-xl font-bold text-gray-800">Próximos compromissos</h3>
           <select id="agendaPeriod" class="input w-32">
             <option value="7">7 dias</option>
             <option value="30">30 dias</option>
             <option value="90">90 dias</option>
           </select>
         </div>
-        <ul id="agendaList" class="divide-y"></ul>
-        <div id="agendaEmpty" class="empty-state hidden">
-          <p>Nenhum compromisso futuro.</p>
+        <ul id="agendaList" class="space-y-3"></ul>
+        <div
+          id="agendaEmpty"
+          class="hidden text-center bg-white border border-dashed rounded-2xl p-6 text-gray-600"
+        >
+          <i class="fas fa-calendar text-3xl mb-2 text-gray-400" aria-hidden="true"></i>
+          <p class="mb-2">Nenhum compromisso futuro.</p>
           <button id="btnAgendaAddVisit" class="btn-primary">Registrar visita</button>
         </div>
       </div>

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -837,14 +837,27 @@ export function initAgronomoDashboard() {
           {
             label: 'Visitas',
             data,
-            borderColor: '#16a34a',
-            backgroundColor: '#bbf7d0',
+            borderColor: '#166534',
+            backgroundColor: 'rgba(22,101,52,0.1)',
             tension: 0.1,
             fill: true,
           },
         ],
       },
-      options: { scales: { y: { beginAtZero: true, ticks: { precision: 0 } } } },
+      options: {
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: { precision: 0, color: '#4b5563' },
+            grid: { color: 'rgba(0,0,0,0.05)' },
+          },
+          x: {
+            ticks: { color: '#4b5563' },
+            grid: { color: 'rgba(0,0,0,0.03)' },
+          },
+        },
+        plugins: { legend: { labels: { color: '#4b5563' } } },
+      },
     });
   }
 
@@ -893,11 +906,21 @@ export function initAgronomoDashboard() {
           {
             label: 'Toneladas',
             data,
-            backgroundColor: '#16a34a',
+            backgroundColor: '#166534',
           },
         ],
       },
-      options: { scales: { y: { beginAtZero: true } } },
+      options: {
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: { color: '#4b5563' },
+            grid: { color: 'rgba(0,0,0,0.05)' },
+          },
+          x: { ticks: { color: '#4b5563' }, grid: { color: 'rgba(0,0,0,0.03)' } },
+        },
+        plugins: { legend: { labels: { color: '#4b5563' } } },
+      },
     });
   }
 
@@ -973,14 +996,14 @@ export function initAgronomoDashboard() {
     items.forEach((it) => {
       const when = new Date(it.when);
       const li = document.createElement('li');
-      li.className = 'flex justify-between items-start gap-2 py-2';
+      li.className = 'rounded-xl border border-gray-100 bg-white p-3 hover:bg-gray-50 transition flex justify-between items-start gap-2';
       const info = document.createElement('div');
-      info.className = 'flex-1';
+      info.className = 'flex-1 space-y-1';
       const dt = document.createElement('div');
-      dt.className = 'text-sm';
+      dt.className = 'text-sm text-gray-600';
       dt.textContent = when.toLocaleString('pt-BR');
       const nameDiv = document.createElement('div');
-      nameDiv.className = 'font-semibold';
+      nameDiv.className = 'font-semibold text-gray-800';
       let name = '(sem nome)';
       let type = 'Lead';
       if (it.clientId) {
@@ -992,17 +1015,17 @@ export function initAgronomoDashboard() {
         name = l?.name || '(sem nome)';
         type = 'Lead';
       }
-      nameDiv.innerHTML = `<span class="text-xs bg-blue-100 text-blue-800 rounded px-1 mr-1">${type}</span>${name}`;
+      nameDiv.innerHTML = `<span class="text-xs rounded px-1.5 py-0.5 bg-blue-50 text-blue-700 mr-1">${type}</span>${name}`;
       info.appendChild(dt);
       info.appendChild(nameDiv);
       if (it.note) {
         const note = document.createElement('div');
-        note.className = 'text-xs text-gray-600';
+        note.className = 'text-xs text-gray-500';
         note.textContent = it.note;
         info.appendChild(note);
       }
       const btn = document.createElement('button');
-      btn.className = 'btn-secondary text-sm';
+      btn.className = 'btn-secondary text-sm min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/40 hover:bg-gray-200';
       btn.textContent = 'Concluir';
       btn.addEventListener('click', () => {
         updateAgenda(it.id, { done: true });

--- a/public/style.css
+++ b/public/style.css
@@ -1125,3 +1125,10 @@ body.has-modal{overflow:hidden;}
 .timeline-item{position:relative;margin-bottom:1rem;}
 .timeline-badge{position:absolute;left:-0.75rem;top:0.25rem;width:0.5rem;height:0.5rem;border-radius:50%;background:var(--brand-green);}
 .card{background:#fff;border:1px solid #E5E7EB;border-radius:8px;padding:1rem;}
+/* Utility classes for Agronomo Home */
+.kpi-card { @apply bg-white border border-gray-100 rounded-2xl p-4 md:p-5 shadow-sm; }
+.kpi-icon { @apply w-9 h-9 rounded-full flex items-center justify-center bg-emerald-50 text-emerald-700; }
+.kpi-value:empty { @apply skeleton h-8 w-16; }
+.chip-action { @apply inline-flex items-center gap-2 px-3 py-2 rounded-xl border border-gray-200 bg-white hover:shadow transition min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/40; }
+.card-soft { @apply bg-white border border-gray-100 rounded-2xl p-4 md:p-5 shadow-sm; }
+.skeleton { @apply animate-pulse bg-gray-200 rounded; }


### PR DESCRIPTION
## Summary
- restyle agronomo home KPIs, charts, shortcuts, and agenda cards
- add utility CSS classes for dashboard home components
- apply brand colors to charts and agenda items

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74e875728832eb915bf8182a3c8b1