### PR TITLE
feat: add client and lead detail view with visit history

### DIFF
--- a/public/client-details.html
+++ b/public/client-details.html
@@ -32,7 +32,7 @@
       <div class="space-y-1">
         <div id="summaryName" class="font-semibold"></div>
         <div id="summaryProperty" class="text-sm text-gray-600"></div>
-        <div id="summaryInterest" class="text-sm text-gray-600"></div>
+        <span id="summaryInterest" class="hidden text-xs font-semibold px-2 py-1 rounded"></span>
       </div>
       <button id="btnViewMap" class="btn-secondary mt-4">Ver no mapa</button>
     </section>
@@ -46,13 +46,7 @@
     </section>
 
     <section id="historySection" class="bg-white rounded-lg shadow p-6">
-      <div class="flex justify-between items-center mb-4">
-        <h2 class="text-xl font-bold text-gray-800">Histórico</h2>
-        <div class="flex gap-2">
-          <button id="btnRegisterVisit" class="btn-secondary text-sm">Registrar visita</button>
-          <button id="btnNewSale" class="btn-primary text-sm">Nova venda</button>
-        </div>
-      </div>
+      <h2 class="text-xl font-bold text-gray-800 mb-4">Histórico de visitas</h2>
       <div id="historyTimeline"></div>
     </section>
   </main>

--- a/public/js/pages/client-details.js
+++ b/public/js/pages/client-details.js
@@ -5,19 +5,27 @@
 // (firebase.firestore()) to keep the code consistent with the rest of the
 // project.
 
+import { getLeads } from '../stores/leadsStore.js';
+import { getVisits } from '../stores/visitsStore.js';
+
 export function initClientDetails(userId, userRole) {
   const params = new URLSearchParams(window.location.search);
   const clientId = params.get('clientId');
+  const leadId = params.get('leadId');
   const from = params.get('from') || 'agronomo';
+  const isLead = !!leadId;
+  const id = leadId || clientId;
 
-  if (!clientId) return;
+  if (!id) return;
 
   const db = firebase.firestore();
 
   const clientNameHeader = document.getElementById('clientNameHeader');
   const summaryName = document.getElementById('summaryName');
   const summaryProperty = document.getElementById('summaryProperty');
+  const summaryInterest = document.getElementById('summaryInterest');
   const propertiesList = document.getElementById('propertiesList');
+  const historyTimeline = document.getElementById('historyTimeline');
 
   // --- Navegação ----------------------------------------------------------
   document.getElementById('backBtn')?.addEventListener('click', () => {
@@ -30,17 +38,72 @@ export function initClientDetails(userId, userRole) {
     }
   });
 
-  // --- Carrega dados do cliente ------------------------------------------
+  // --- Utilitários --------------------------------------------------------
+  function formatDate(str) {
+    const d = new Date(str);
+    return d.toLocaleDateString('pt-BR') + ' ' + d.toLocaleTimeString('pt-BR', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function interestClass(interest) {
+    if (interest === 'Interessado') return 'bg-green-100 text-green-800';
+    if (interest === 'Sem interesse') return 'bg-red-100 text-red-800';
+    return 'bg-yellow-100 text-yellow-800';
+  }
+
+  // --- Carrega dados ------------------------------------------------------
   async function loadClient() {
     try {
       const snap = await db.collection('clients').doc(clientId).get();
       const data = snap.data();
       if (clientNameHeader) clientNameHeader.textContent = data?.name || 'Cliente';
       if (summaryName) summaryName.textContent = data?.name || '';
+      if (summaryInterest) summaryInterest.classList.add('hidden');
     } catch (err) {
       console.error('Erro ao carregar cliente:', err);
       if (clientNameHeader) clientNameHeader.textContent = 'Erro ao carregar';
     }
+  }
+
+  function loadLead() {
+    const lead = getLeads().find((l) => l.id === leadId);
+    if (!lead) return;
+    if (clientNameHeader) clientNameHeader.textContent = lead.name || 'Lead';
+    if (summaryName) summaryName.textContent = lead.name || '';
+    if (summaryProperty) summaryProperty.textContent = lead.farmName || '—';
+    if (summaryInterest) {
+      summaryInterest.textContent = lead.interest || '';
+      summaryInterest.className = `text-xs font-semibold px-2 py-1 rounded ${interestClass(lead.interest)}`;
+      summaryInterest.classList.remove('hidden');
+    }
+    document.getElementById('propertiesSection')?.classList.add('hidden');
+  }
+
+  function loadVisits() {
+    if (!historyTimeline) return;
+    const visits = getVisits().filter(
+      (v) => v.refId === id && v.type === (isLead ? 'lead' : 'cliente')
+    );
+    if (!visits.length) {
+      historyTimeline.innerHTML = '<p class="text-gray-500">Nenhuma visita registrada.</p>';
+      return;
+    }
+    visits.sort((a, b) => new Date(b.at) - new Date(a.at));
+    historyTimeline.innerHTML = '';
+    visits.forEach((v) => {
+      const card = document.createElement('div');
+      card.className = 'mb-4 pl-4 border-l-2 border-green-600';
+      const interest = isLead && v.interest
+        ? `<span class="ml-2 ${interestClass(v.interest)} text-xs font-medium px-2 py-0.5 rounded">${v.interest}</span>`
+        : '';
+      card.innerHTML = `
+        <div class="text-sm text-gray-500">${formatDate(v.at)}${interest}</div>
+        <div class="mt-1">${v.notes || ''}</div>
+      `;
+      historyTimeline.appendChild(card);
+    });
   }
 
   // --- Lista propriedades -------------------------------------------------
@@ -111,7 +174,12 @@ export function initClientDetails(userId, userRole) {
     ?.addEventListener('click', addProperty);
 
   // --- Inicialização ------------------------------------------------------
-  loadClient();
-  loadProperties();
+  if (isLead) {
+    loadLead();
+  } else {
+    loadClient();
+    loadProperties();
+  }
+  loadVisits();
 }
 


### PR DESCRIPTION
## Summary
- show lead interest status and visit history on client details screen
- support viewing leads in client details page with local storage data

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a1f6039c832e816050c270a43f6e