### PR TITLE
feat: add lead visit tracking page

### DIFF
--- a/public/js/pages/agro-map.js
+++ b/public/js/pages/agro-map.js
@@ -62,7 +62,7 @@ export function plotLeads(leads) {
       const loc = l.farmName || `(${l.lat.toFixed(4)}, ${l.lng.toFixed(4)})`;
       const interest = l.interest ? `<br>Interesse: ${l.interest}` : '';
       marker.bindPopup(
-        `<b>${l.name || 'Lead'}</b>${interest}<br>${loc}<br><a href="client-details.html?leadId=${l.id}&from=agronomo">Ver detalhes</a>`
+        `<b>${l.name || 'Lead'}</b>${interest}<br>${loc}<br><a href="lead-details.html?id=${l.id}">Ver detalhes</a>`
       );
     });
 }

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -406,7 +406,7 @@ export function initAgronomoDashboard() {
         it.lead.interest || ''
       }</div>`;
       div.addEventListener('click', () => {
-        location.href = `client-details.html?leadId=${it.lead.id}`;
+        location.href = `lead-details.html?id=${it.lead.id}`;
       });
       listEl.appendChild(div);
     });

--- a/public/js/pages/lead-details.js
+++ b/public/js/pages/lead-details.js
@@ -1,0 +1,140 @@
+// js/pages/lead-details.js
+
+import { db, auth } from '../config/firebase.js';
+import {
+  doc,
+  getDoc,
+  collection,
+  addDoc,
+  onSnapshot,
+  query,
+  orderBy,
+  serverTimestamp,
+  Timestamp
+} from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+import { showToast, showSpinner, hideSpinner } from '../services/ui.js';
+
+export function initLeadDetails(userId, userRole) {
+  const params = new URLSearchParams(window.location.search);
+  const leadId = params.get('id');
+  if (!leadId) return;
+
+  const backBtn = document.getElementById('backBtn');
+  backBtn?.addEventListener('click', () => {
+    window.location.href = 'dashboard-agronomo.html';
+  });
+
+  const leadNameHeader = document.getElementById('leadNameHeader');
+  const leadName = document.getElementById('leadName');
+  const leadPhone = document.getElementById('leadPhone');
+  const leadStage = document.getElementById('leadStage');
+  const visitsTimeline = document.getElementById('visitsTimeline');
+  const addVisitForm = document.getElementById('addVisitForm');
+  const visitDate = document.getElementById('visitDate');
+  const visitSummary = document.getElementById('visitSummary');
+  const visitNotes = document.getElementById('visitNotes');
+  const visitOutcome = document.getElementById('visitOutcome');
+  const visitNextStep = document.getElementById('visitNextStep');
+
+  if (visitDate) {
+    const now = new Date();
+    visitDate.value = now.toISOString().slice(0, 16);
+  }
+
+  const leadRef = doc(db, 'leads', leadId);
+  onSnapshot(leadRef, (snap) => {
+    const data = snap.data();
+    if (!data) return;
+    const name = data.name || data.nomeContato || 'Lead';
+    if (leadNameHeader) leadNameHeader.textContent = name;
+    if (leadName) leadName.textContent = name;
+    if (leadPhone) leadPhone.textContent = data.phone || data.phoneNumber || '';
+    if (leadStage && data.stage) {
+      leadStage.textContent = data.stage;
+      leadStage.classList.remove('hidden');
+    }
+
+    const canAdd =
+      userRole === 'admin' ||
+      userRole === 'agronomo' ||
+      (userRole === 'operador' && data.assignedTo === userId);
+    addVisitForm?.classList.toggle('hidden', !canAdd);
+  });
+
+  function formatDate(ts) {
+    if (!ts) return '';
+    const d = ts.toDate ? ts.toDate() : new Date(ts);
+    return d.toLocaleString('pt-BR', {
+      dateStyle: 'short',
+      timeStyle: 'short'
+    });
+  }
+
+  function formatRole(role) {
+    const roles = {
+      admin: 'Admin',
+      agronomo: 'Agrônomo',
+      operador: 'Operador',
+      cliente: 'Cliente'
+    };
+    return roles[role] || role || '';
+  }
+
+  if (visitsTimeline) showSpinner(visitsTimeline);
+
+  const visitsRef = collection(db, `leads/${leadId}/visits`);
+  const visitsQuery = query(visitsRef, orderBy('date', 'desc'));
+  onSnapshot(visitsQuery, (snap) => {
+    if (!visitsTimeline) return;
+    hideSpinner(visitsTimeline);
+    if (snap.empty) {
+      visitsTimeline.innerHTML = '<p class="text-gray-500">Nenhuma visita registrada.</p>';
+      return;
+    }
+    visitsTimeline.innerHTML = '';
+    snap.forEach((docSnap) => {
+      const v = docSnap.data();
+      const card = document.createElement('div');
+      card.className = 'mb-4 pl-4 border-l-2 border-green-600';
+      card.innerHTML = `
+        <div class="text-sm text-gray-500">${formatDate(v.date || v.createdAt)} por ${formatRole(v.authorRole)}</div>
+        <div class="font-semibold">${v.summary || ''}</div>
+        ${v.notes ? `<div class="mt-1 text-sm">${v.notes}</div>` : ''}
+        ${v.outcome ? `<div class="mt-1 text-sm text-gray-600">Resultado: ${v.outcome}</div>` : ''}
+        ${v.nextStep ? `<div class="mt-1 text-sm text-gray-600">Próximo passo: ${v.nextStep}</div>` : ''}
+      `;
+      visitsTimeline.appendChild(card);
+    });
+  });
+
+  addVisitForm?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const summary = visitSummary?.value.trim();
+    if (!summary) {
+      showToast('Informe o resumo da visita.', 'error');
+      return;
+    }
+    try {
+      await addDoc(visitsRef, {
+        date: visitDate?.value ? Timestamp.fromDate(new Date(visitDate.value)) : Timestamp.now(),
+        authorId: auth.currentUser.uid,
+        authorRole: userRole,
+        summary,
+        notes: visitNotes?.value.trim() || '',
+        outcome: visitOutcome?.value || 'realizada',
+        nextStep: visitNextStep?.value.trim() || null,
+        attachments: [],
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        relatedType: 'lead',
+        relatedId: leadId
+      });
+      addVisitForm.reset();
+      if (visitDate) visitDate.value = new Date().toISOString().slice(0, 16);
+      showToast('Visita registrada com sucesso!', 'success');
+    } catch (err) {
+      console.error('Erro ao adicionar visita:', err);
+      showToast('Erro ao adicionar visita.', 'error');
+    }
+  });
+}

--- a/public/js/pages/mapa-geral.js
+++ b/public/js/pages/mapa-geral.js
@@ -24,7 +24,7 @@ export function initMapaGeral() {
         if (lead.lat && lead.lng) {
           const color = lead.stage === 'Visitado' ? 'green' : 'blue';
           const marker = L.circleMarker([lead.lat, lead.lng], { color }).addTo(map);
-          const popup = `<b>${lead.nomeContato || 'Lead'}</b><br><a href="dashboard-agronomo.html?leadId=${docSnap.id}" class="text-blue-600 underline">Abrir lead</a>`;
+          const popup = `<b>${lead.nomeContato || 'Lead'}</b><br><a href="lead-details.html?id=${docSnap.id}" class="text-blue-600 underline">Abrir lead</a>`;
           marker.bindPopup(popup);
         }
       });

--- a/public/js/services/auth.js
+++ b/public/js/services/auth.js
@@ -12,6 +12,7 @@ import { initFormulasAdmin } from '../pages/formulas-admin.js';
 import { initAgronomoDashboard } from '../pages/dashboard-agronomo.js';
 import { initClienteDashboard } from '../pages/dashboard-cliente.js';
 import { initClientDetails } from '../pages/client-details.js';
+import { initLeadDetails } from '../pages/lead-details.js';
 import { initPropertyDetails } from '../pages/property-details.js';
 import { initPlotDetails } from '../pages/plot-details.js';
 import { initPlotReport } from '../pages/plot-report.js';
@@ -149,6 +150,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 initClienteDashboard(user.uid, userRole);
             } else if (document.getElementById('client-details-marker')) {
                 initClientDetails(user.uid, userRole);
+            } else if (document.getElementById('lead-details-marker')) {
+                initLeadDetails(user.uid, userRole);
             } else if (document.getElementById('property-details-marker')) {
                 initPropertyDetails(user.uid, userRole);
             } else if (document.getElementById('plot-details-marker')) {

--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta name="theme-color" content="#166534">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="manifest" href="/manifest.json">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orgânia - Detalhes do Lead</title>
+  <script type="module" src="js/app.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-gray-100">
+  <div id="lead-details-marker" class="hidden"></div>
+  <header class="bg-white shadow-lg sticky top-0 z-20">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between items-center h-16">
+        <div class="flex items-center gap-4">
+          <a id="backBtn" class="text-gray-500 hover:text-gray-800" title="Voltar"><i class="fas fa-arrow-left"></i></a>
+          <h1 id="leadNameHeader" class="text-2xl font-bold" style="color: var(--brand-green);">Carregando...</h1>
+        </div>
+        <button onclick="logout()" class="px-4 py-2 bg-red-600 text-white font-bold rounded-lg hover:bg-red-700 text-sm">Sair</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8 space-y-6">
+    <section class="bg-white rounded-lg shadow p-6">
+      <h2 class="text-xl font-bold mb-4">Dados do Lead</h2>
+      <div class="space-y-1">
+        <div id="leadName" class="font-semibold"></div>
+        <div id="leadPhone" class="text-sm text-gray-600"></div>
+        <span id="leadStage" class="hidden text-xs font-semibold px-2 py-1 rounded"></span>
+      </div>
+    </section>
+
+    <section class="bg-white rounded-lg shadow p-6">
+      <h2 class="text-xl font-bold mb-4">Visitas</h2>
+      <form id="addVisitForm" class="grid gap-4 mb-6">
+        <div class="field">
+          <label for="visitDate">Data/Hora</label>
+          <input id="visitDate" type="datetime-local" class="input" required />
+        </div>
+        <div class="field">
+          <label for="visitSummary">Resumo*</label>
+          <input id="visitSummary" class="input" required />
+        </div>
+        <div class="field">
+          <label for="visitNotes">Notas</label>
+          <textarea id="visitNotes" class="input"></textarea>
+        </div>
+        <div class="field">
+          <label for="visitOutcome">Resultado</label>
+          <select id="visitOutcome" class="input">
+            <option value="realizada">Realizada</option>
+            <option value="reagendada">Reagendada</option>
+            <option value="cancelada">Cancelada</option>
+            <option value="sem_contato">Sem contato</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="visitNextStep">Próximo passo</label>
+          <input id="visitNextStep" class="input" />
+        </div>
+        <div class="flex gap-2 justify-end">
+          <button type="submit" class="btn-primary">Salvar</button>
+        </div>
+      </form>
+      <div id="visitsTimeline"></div>
+    </section>
+  </main>
+
+  <script src="/__/firebase/9.6.1/firebase-app-compat.js"></script>
+  <script src="/__/firebase/9.6.1/firebase-auth-compat.js"></script>
+  <script src="/__/firebase/9.6.1/firebase-firestore-compat.js"></script>
+  <script src="/__/firebase/init.js"></script>
+  <script type="module" src="js/services/auth.js"></script>
+  <script type="module" src="js/pages/lead-details.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add lead-details page with form and timeline to register visits
- integrate lead visits with Firestore and UI helpers
- link lead lists and maps to new details page and auth init

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a9884f14832e9a60a8d77b7a32c9