### PR TITLE
Add open button for lead cards

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -310,6 +310,12 @@ export function initAgronomoDashboard() {
           location.href = `client-details.html?clientId=${it.id}&from=agronomo`;
         });
         actions.appendChild(openBtn);
+      } else if (it.type === 'lead') {
+        const openLink = document.createElement('a');
+        openLink.className = 'btn-secondary flex-1 text-center';
+        openLink.textContent = 'Abrir';
+        openLink.href = `lead-details.html?id=${it.id}`;
+        actions.appendChild(openLink);
       }
       div.appendChild(actions);
       if (highlightId && it.id === highlightId) {


### PR DESCRIPTION
## Summary
- show an Abrir button on lead cards that goes to lead-details

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68a9acadd088832e8d2cd2bdb9505c12