### PR TITLE
feat: improve lead details and contact list

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -347,6 +347,10 @@ export function initAgronomoDashboard(userId, userRole) {
     items.forEach((it) => {
       const div = document.createElement('div');
       div.className = 'p-4 bg-white rounded-2xl shadow-md';
+      if (it.type === 'lead') {
+        div.classList.add('lead-card');
+        div.dataset.id = it.id;
+      }
       div.innerHTML = `<div class="font-semibold">${
         it.name || '(sem nome)'
       }</div><div class="text-sm text-gray-600">${it.farmName || ''}</div>`;
@@ -355,14 +359,19 @@ export function initAgronomoDashboard(userId, userRole) {
       const visitBtn = document.createElement('button');
       visitBtn.className = 'btn-secondary flex-1';
       visitBtn.textContent = 'Registrar visita';
-      visitBtn.addEventListener('click', () => {
-        openVisitModal();
-        document.querySelector(
-          `input[name='visitTarget'][value='${it.type}']`
-        ).checked = true;
-        populateVisitSelect(it.type);
-        visitSelect.value = it.id;
-      });
+      if (it.type === 'lead') {
+        visitBtn.classList.add('btn-registrar-visita');
+        visitBtn.dataset.id = it.id;
+      } else {
+        visitBtn.addEventListener('click', () => {
+          openVisitModal();
+          document.querySelector(
+            `input[name='visitTarget'][value='${it.type}']`
+          ).checked = true;
+          populateVisitSelect(it.type);
+          visitSelect.value = it.id;
+        });
+      }
       actions.appendChild(visitBtn);
       if (it.type === 'cliente') {
         const openBtn = document.createElement('button');
@@ -372,12 +381,6 @@ export function initAgronomoDashboard(userId, userRole) {
           location.href = `client-details.html?clientId=${it.id}&from=agronomo`;
         });
         actions.appendChild(openBtn);
-      } else if (it.type === 'lead') {
-        const openLink = document.createElement('a');
-        openLink.className = 'btn-secondary flex-1 text-center';
-        openLink.textContent = 'Abrir';
-        openLink.href = `lead-details.html?id=${it.id}`;
-        actions.appendChild(openLink);
       }
       div.appendChild(actions);
       if (highlightId && it.id === highlightId) {
@@ -389,6 +392,20 @@ export function initAgronomoDashboard(userId, userRole) {
     listEl.classList.toggle('hidden', items.length === 0);
     emptyEl.classList.toggle('hidden', items.length !== 0);
   }
+
+  const contactsEl = document.getElementById('contactsList');
+  contactsEl?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.btn-registrar-visita');
+    if (btn) {
+      e.stopPropagation();
+      openLeadVisitModal(btn.dataset.id);
+      return;
+    }
+    const card = e.target.closest('.lead-card');
+    if (card) {
+      location.href = `lead-details.html?id=${card.dataset.id}`;
+    }
+  });
 
   function bindContactsEvents() {
     const searchEl = document.getElementById('contactsSearch');

--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -37,23 +37,33 @@
     </section>
 
     <section class="bg-white rounded-lg shadow p-6">
-      <h2 class="text-xl font-bold mb-4">Visitas</h2>
-      <form id="addVisitForm" class="grid gap-4 mb-6">
+      <div class="flex justify-between items-center mb-4">
+        <h2 class="text-xl font-bold">Visitas</h2>
+        <button id="btnAddVisit" class="btn-primary hidden">Adicionar visita</button>
+      </div>
+      <div id="visitsTimeline"></div>
+    </section>
+  </main>
+  <!-- Modal de registro de visita -->
+  <div id="leadAddVisitModal" class="modal hidden">
+    <div class="modal-card w-full max-w-md">
+      <h3 class="font-semibold mb-4">Registrar visita</h3>
+      <form id="leadAddVisitForm" class="grid gap-4">
         <div class="field">
-          <label for="visitDate">Data/Hora</label>
-          <input id="visitDate" type="datetime-local" class="input" required />
+          <label for="leadVisitDate">Data/Hora</label>
+          <input id="leadVisitDate" type="datetime-local" class="input" />
         </div>
         <div class="field">
-          <label for="visitSummary">Resumo*</label>
-          <input id="visitSummary" class="input" required />
+          <label for="leadVisitSummary">Resumo*</label>
+          <input id="leadVisitSummary" class="input" required />
         </div>
         <div class="field">
-          <label for="visitNotes">Notas</label>
-          <textarea id="visitNotes" class="input"></textarea>
+          <label for="leadVisitNotes">Notas</label>
+          <textarea id="leadVisitNotes" class="input"></textarea>
         </div>
         <div class="field">
-          <label for="visitOutcome">Resultado</label>
-          <select id="visitOutcome" class="input">
+          <label for="leadVisitOutcome">Resultado</label>
+          <select id="leadVisitOutcome" class="input">
             <option value="realizada">Realizada</option>
             <option value="reagendada">Reagendada</option>
             <option value="cancelada">Cancelada</option>
@@ -61,20 +71,17 @@
           </select>
         </div>
         <div class="field">
-          <label for="visitNextStep">Próximo passo</label>
-          <input id="visitNextStep" class="input" />
+          <label for="leadVisitNextStep">Próximo passo</label>
+          <input id="leadVisitNextStep" class="input" />
         </div>
         <div class="flex gap-2 justify-end">
+          <button type="button" id="btnLeadVisitClose" class="btn-secondary">Cancelar</button>
           <button type="submit" class="btn-primary">Salvar</button>
         </div>
       </form>
-      <div id="visitsTimeline"></div>
-    </section>
-  </main>
+    </div>
+  </div>
 
-  <script src="/__/firebase/9.6.1/firebase-app-compat.js"></script>
-  <script src="/__/firebase/9.6.1/firebase-auth-compat.js"></script>
-  <script src="/__/firebase/9.6.1/firebase-firestore-compat.js"></script>
   <script src="/__/firebase/init.js"></script>
   <script type="module" src="js/services/auth.js"></script>
   <script type="module" src="js/pages/lead-details.js"></script>


### PR DESCRIPTION
## Summary
- show lead name and stage in header with realtime fallback
- add visit registration modal and timeline refresh
- allow opening lead details from agronomo contacts tab

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install --no-save vitest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b84ec3c4832ebdb1cd64ce2e7298