### PR TITLE
Fix Firebase init error on lead details page

### DIFF
--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -82,6 +82,9 @@
     </div>
   </div>
 
+  <script src="/__/firebase/9.6.1/firebase-app-compat.js"></script>
+  <script src="/__/firebase/9.6.1/firebase-auth-compat.js"></script>
+  <script src="/__/firebase/9.6.1/firebase-firestore-compat.js"></script>
   <script src="/__/firebase/init.js"></script>
   <script type="module" src="js/services/auth.js"></script>
   <script type="module" src="js/pages/lead-details.js"></script>


### PR DESCRIPTION
## Summary
- add Firebase compat SDK scripts before init.js in lead-details page to avoid hosting init error

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run --reporter=dot` *(fails: 403 Forbidden fetching package)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bbe937e4832e9331895fc844abc5