### PR TITLE
feat: enhance lead data card

### DIFF
--- a/public/js/pages/lead-details.js
+++ b/public/js/pages/lead-details.js
@@ -30,6 +30,9 @@ export function initLeadDetails(userId, userRole) {
   const leadNameHeader = document.getElementById('leadNameHeader');
   const leadName = document.getElementById('leadName');
   const leadPhone = document.getElementById('leadPhone');
+  const leadEmail = document.getElementById('leadEmail');
+  const leadProperty = document.getElementById('leadProperty');
+  const leadOrigin = document.getElementById('leadOrigin');
   const leadStage = document.getElementById('leadStage');
   const visitsTimeline = document.getElementById('visitsTimeline');
   const visitFilters = document.getElementById('visitFilters');
@@ -49,6 +52,14 @@ export function initLeadDetails(userId, userRole) {
 
   const leadRef = doc(db, 'leads', leadId);
 
+  const STAGE_COLORS = {
+    Novo: 'bg-yellow-100 text-yellow-800',
+    Interessado: 'bg-blue-100 text-blue-800',
+    'Na dúvida': 'bg-purple-100 text-purple-800',
+    Convertido: 'bg-green-100 text-green-800',
+    'Sem interesse': 'bg-gray-200 text-gray-800',
+  };
+
   let leadLoaded = false;
   let usingLocalData = false;
   let visitsCache = [];
@@ -61,9 +72,14 @@ export function initLeadDetails(userId, userRole) {
     if (leadName) leadName.textContent = name;
     if (leadPhone)
       leadPhone.textContent = lead.phone || lead.phoneNumber || '';
+    if (leadEmail) leadEmail.textContent = lead.email || '';
+    if (leadProperty)
+      leadProperty.textContent = lead.propertyName || lead.property || '';
+    if (leadOrigin) leadOrigin.textContent = lead.origin || lead.source || '';
     if (leadStage && lead.stage) {
+      const color = STAGE_COLORS[lead.stage] || 'bg-gray-100 text-gray-800';
       leadStage.textContent = lead.stage;
-      leadStage.classList.remove('hidden');
+      leadStage.className = `inline-block text-xs font-semibold px-2 py-1 rounded ${color}`;
     }
     if (visitsTimeline) {
       hideSpinner(visitsTimeline);
@@ -100,9 +116,14 @@ export function initLeadDetails(userId, userRole) {
     if (leadName) leadName.textContent = name;
     if (leadPhone)
       leadPhone.textContent = data.phone || data.phoneNumber || '';
+    if (leadEmail) leadEmail.textContent = data.email || '';
+    if (leadProperty)
+      leadProperty.textContent = data.propertyName || data.property || '';
+    if (leadOrigin) leadOrigin.textContent = data.origin || data.source || '';
     if (leadStage && data.stage) {
+      const color = STAGE_COLORS[data.stage] || 'bg-gray-100 text-gray-800';
       leadStage.textContent = data.stage;
-      leadStage.classList.remove('hidden');
+      leadStage.className = `inline-block text-xs font-semibold px-2 py-1 rounded ${color}`;
     }
     const canAdd =
       userRole === 'admin' ||

--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -27,14 +27,34 @@
   </header>
 
   <main class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8 space-y-6">
-    <section class="bg-white rounded-lg shadow p-6">
+    <div class="bg-white rounded-lg shadow p-6">
       <h2 class="text-xl font-bold mb-4">Dados do Lead</h2>
-      <div class="space-y-1">
-        <div id="leadName" class="font-semibold"></div>
-        <div id="leadPhone" class="text-sm text-gray-600"></div>
-        <span id="leadStage" class="hidden text-xs font-semibold px-2 py-1 rounded"></span>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <span class="block text-xs text-gray-500">Nome</span>
+          <div id="leadName" class="font-semibold"></div>
+        </div>
+        <div>
+          <span class="block text-xs text-gray-500">Telefone</span>
+          <div id="leadPhone" class="text-sm text-gray-600"></div>
+        </div>
+        <div>
+          <span class="block text-xs text-gray-500">E-mail</span>
+          <div id="leadEmail" class="text-sm text-gray-600"></div>
+        </div>
+        <div>
+          <span class="block text-xs text-gray-500">Propriedade</span>
+          <div id="leadProperty" class="text-sm text-gray-600"></div>
+        </div>
+        <div>
+          <span class="block text-xs text-gray-500">Origem</span>
+          <div id="leadOrigin" class="text-sm text-gray-600"></div>
+        </div>
+        <div class="flex items-center">
+          <span id="leadStage" class="hidden text-xs font-semibold px-2 py-1 rounded"></span>
+        </div>
       </div>
-    </section>
+    </div>
 
     <section class="bg-white rounded-lg shadow p-6">
       <div class="flex justify-between items-center mb-4">


### PR DESCRIPTION
## Summary
- Refactor lead details section into a responsive card with two-column grid and additional info fields
- Display lead stage with color-coded badge styling

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @playwright/test)*
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c5b1f7dc832ea33e3823533f5fb2