### PR TITLE
feat: convert lead into client

### DIFF
--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -31,6 +31,7 @@
               <a id="editLead" class="action-icon" title="Editar"><i class="fas fa-edit"></i></a>
               <a id="callLead" class="action-icon" title="Ligar"><i class="fas fa-phone"></i></a>
               <a id="messageLead" class="action-icon" title="Mensagem"><i class="fas fa-comment-dots"></i></a>
+              <button id="convertLead" class="btn-primary text-xs px-2 py-1">Converter em Cliente</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add 'Converter em Cliente' button to lead details
- implement lead conversion handler creating client document and updating lead stage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c9037d3c832e8be1d4551e4916b1