### PR TITLE
feat: allow editing lead details and remove visit filters

### DIFF
--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -75,11 +75,6 @@
         <h2 class="text-xl font-bold">Visitas</h2>
         <button id="btnAddVisit" class="btn-primary hidden">Adicionar visita</button>
       </div>
-      <div id="visitFilters" class="flex gap-2 mb-4">
-        <button class="btn-primary" data-filter="all">Todas</button>
-        <button class="btn-secondary" data-filter="future">Futuras</button>
-        <button class="btn-secondary" data-filter="past">Passadas</button>
-      </div>
       <ul id="visitsTimeline" class="timeline"></ul>
     </section>
   </main>
@@ -127,6 +122,42 @@
         </div>
         <div class="flex gap-2 justify-end">
           <button type="button" id="btnLeadVisitClose" class="btn-secondary">Cancelar</button>
+          <button type="submit" class="btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Modal de edição do lead -->
+  <div id="editLeadModal" class="modal hidden">
+    <div class="modal-card w-full max-w-md relative">
+      <button type="button" id="btnEditLeadCloseIcon" aria-label="Fechar" class="btn-icon absolute top-2 right-2 text-gray-500 hover:text-gray-700">
+        <i class="fas fa-times"></i>
+      </button>
+      <h3 class="font-semibold mb-4">Editar Lead</h3>
+      <form id="editLeadForm" class="grid gap-4">
+        <div class="field">
+          <label for="editLeadName">Nome</label>
+          <input id="editLeadName" class="input" />
+        </div>
+        <div class="field">
+          <label for="editLeadPhone">Telefone</label>
+          <input id="editLeadPhone" class="input" />
+        </div>
+        <div class="field">
+          <label for="editLeadEmail">E-mail</label>
+          <input id="editLeadEmail" class="input" />
+        </div>
+        <div class="field">
+          <label for="editLeadProperty">Propriedade</label>
+          <input id="editLeadProperty" class="input" />
+        </div>
+        <div class="field">
+          <label for="editLeadOrigin">Origem</label>
+          <input id="editLeadOrigin" class="input" />
+        </div>
+        <div class="flex gap-2 justify-end">
+          <button type="button" id="btnEditLeadCancel" class="btn-secondary">Cancelar</button>
           <button type="submit" class="btn-primary">Salvar</button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- enable editing lead information via modal on lead-details page
- remove visit filtering UI and logic

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac478641ac832e9ec9ffb42d0d65fe