### PR TITLE
Improve modal accessibility and focus handling

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -244,8 +244,8 @@
   </nav>
 
   <div id="quickActionsModal" class="modal hidden">
-    <div class="modal-card">
-      <h3 class="mb-4 font-semibold">Ações Rápidas</h3>
+    <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="quickActionsTitle">
+      <h3 id="quickActionsTitle" class="mb-4 font-semibold">Ações Rápidas</h3>
       <div class="flex flex-col gap-2 mb-4">
         <button id="btnQuickAddContato" class="btn-primary">Adicionar contato</button>
         <button id="btnQuickRegVisita" class="btn-primary">Registrar Visita</button>
@@ -255,8 +255,8 @@
   </div>
 
   <div id="visitModal" class="modal hidden">
-    <div class="modal-card max-w-xl w-full">
-      <h3 class="mb-4 font-semibold">Registrar Visita</h3>
+    <div class="modal-card max-w-xl w-full" role="dialog" aria-modal="true" aria-labelledby="visitModalTitle">
+      <h3 id="visitModalTitle" class="mb-4 font-semibold">Registrar Visita</h3>
       <form id="visitForm" class="grid gap-4">
         <div>
           <label><input type="radio" name="visitTarget" value="cliente" checked /> Cliente</label>
@@ -318,8 +318,8 @@
   </div>
 
   <div id="saleModal" class="modal hidden">
-    <div class="modal-card max-w-md w-full">
-      <h3 class="mb-4 font-semibold">Registrar Venda</h3>
+    <div class="modal-card max-w-md w-full" role="dialog" aria-modal="true" aria-labelledby="saleModalTitle">
+      <h3 id="saleModalTitle" class="mb-4 font-semibold">Registrar Venda</h3>
       <form id="saleForm" class="grid gap-4">
         <div class="field">
           <label for="saleFormula">Fórmula</label>
@@ -342,8 +342,8 @@
   </div>
 
   <div id="leadVisitModal" class="modal hidden">
-    <div class="modal-card max-w-md w-full">
-      <h3 class="mb-4 font-semibold">Registrar Visita</h3>
+    <div class="modal-card max-w-md w-full" role="dialog" aria-modal="true" aria-labelledby="leadVisitModalTitle">
+      <h3 id="leadVisitModalTitle" class="mb-4 font-semibold">Registrar Visita</h3>
       <form id="leadVisitForm" class="grid gap-4">
         <div class="field">
           <label for="leadVisitDate">Data/Hora</label>
@@ -379,8 +379,8 @@
   </div>
 
   <div id="quickCreateModal" class="modal hidden">
-    <div class="modal-card max-w-xl w-full">
-      <h3 class="mb-4 font-semibold">Cadastro Rápido</h3>
+    <div class="modal-card max-w-xl w-full" role="dialog" aria-modal="true" aria-labelledby="quickCreateModalTitle">
+      <h3 id="quickCreateModalTitle" class="mb-4 font-semibold">Cadastro Rápido</h3>
       <form id="quickCreateForm" class="grid gap-4">
         <div>
           <label><input type="radio" name="quickType" value="cliente" checked /> Cliente</label>

--- a/public/js/pages/agro-bottom-nav.js
+++ b/public/js/pages/agro-bottom-nav.js
@@ -31,7 +31,51 @@ export function bindPlus(handler) {
   btn?.addEventListener('click', handler);
 }
 
+let lastFocusedElement;
+let currentModal;
+let focusableElements = [];
+
+function handleKeydown(e) {
+  if (!currentModal) return;
+  if (e.key === 'Escape') {
+    toggleModal(currentModal, false);
+  } else if (e.key === 'Tab') {
+    if (focusableElements.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+}
+
 export function toggleModal(el, open) {
   if (!el) return;
-  el.classList.toggle('hidden', !open);
+  if (open) {
+    lastFocusedElement = document.activeElement;
+    currentModal = el;
+    el.classList.remove('hidden');
+    focusableElements = el.querySelectorAll(
+      'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])'
+    );
+    focusableElements[0]?.focus();
+    document.addEventListener('keydown', handleKeydown);
+  } else {
+    el.classList.add('hidden');
+    document.removeEventListener('keydown', handleKeydown);
+    currentModal = null;
+    focusableElements = [];
+    lastFocusedElement?.focus();
+  }
 }


### PR DESCRIPTION
## Summary
- add dialog semantics to dashboard agronomist modals
- trap focus and restore previous element when toggling modals

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac842fccb8832e83495ef7970871f0