### PR TITLE
feat: improve agenda accessibility

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -147,16 +147,17 @@
             <option value="90">90 dias</option>
           </select>
         </div>
-        <ul id="agendaList" class="space-y-3"></ul>
-        <div
-          id="agendaEmpty"
-          class="hidden text-center bg-white border border-dashed rounded-2xl p-6 text-gray-500"
-        >
-          <i class="fas fa-calendar text-3xl mb-2 text-gray-400" aria-hidden="true"></i>
-          <p class="mb-2">Nenhum compromisso futuro.</p>
-          <button id="btnAgendaAddVisit" class="btn-primary">Registrar visita</button>
+          <ul id="agendaList" class="space-y-3" aria-live="polite"></ul>
+          <div
+            id="agendaEmpty"
+            class="hidden text-center bg-white border border-dashed rounded-2xl p-6 text-gray-500"
+            aria-live="polite"
+          >
+            <i class="fas fa-calendar text-3xl mb-2 text-gray-400" aria-hidden="true"></i>
+            <p class="mb-2">Nenhum compromisso futuro.</p>
+            <button id="btnAgendaAddVisit" class="btn-primary">Registrar visita</button>
+          </div>
         </div>
-      </div>
     </section>
     <section id="view-contatos" data-view class="hidden">
       <h2 class="p-4 font-semibold">Contatos</h2>

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -1192,7 +1192,7 @@ export function initAgronomoDashboard(userId, userRole) {
     const listEl = document.getElementById('agendaList');
     const emptyEl = document.getElementById('agendaEmpty');
     if (!listEl || !emptyEl) return;
-    listEl.innerHTML = '';
+    listEl.textContent = '';
     const agenda = getAgenda();
     const now = new Date();
     const limit = new Date(now.getTime() + periodDays * 24 * 60 * 60 * 1000);
@@ -1228,7 +1228,12 @@ export function initAgronomoDashboard(userId, userRole) {
         name = l?.name || '(sem nome)';
         type = 'Lead';
       }
-      nameDiv.innerHTML = `<span class="text-xs rounded px-1.5 py-0.5 bg-blue-50 text-blue-700 mr-1">${type}</span>${name}`;
+      const badge = document.createElement('span');
+      badge.className = 'text-xs rounded px-1.5 py-0.5 bg-blue-50 text-blue-700 mr-1';
+      badge.textContent = type;
+      nameDiv.textContent = '';
+      nameDiv.appendChild(badge);
+      nameDiv.appendChild(document.createTextNode(name));
       info.appendChild(dt);
       info.appendChild(nameDiv);
       if (it.note) {


### PR DESCRIPTION
## Summary
- add aria-live to agenda list and empty placeholders
- replace agenda text updates with DOM operations for screen readers

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run --reporter=dot` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8ab8c194832e88823f2787a1b7fb