### PR TITLE
Use satellite imagery for agronomist map

### DIFF
--- a/public/js/pages/mapa-agronomo.js
+++ b/public/js/pages/mapa-agronomo.js
@@ -218,9 +218,15 @@ export function initMapaAgronomo(userId, userRole) {
 
         // Inicializa o mapa Leaflet
         agronomistClientsLeafletMap = L.map('agronomistClientsMap').setView([-14.235, -51.925], 4); // Centro do Brasil
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(agronomistClientsLeafletMap);
+
+        const satelliteLayer = L.tileLayer(
+            'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            {
+                maxZoom: 19,
+                attribution: 'Tiles © Esri — Sources: Esri, Airbus DS, Earthstar Geographics'
+            }
+        );
+        satelliteLayer.addTo(agronomistClientsLeafletMap);
 
         // Inicializa o cluster de marcadores apenas uma vez com o mapa
         agronomistClientsMapMarkers = L.markerClusterGroup(); 


### PR DESCRIPTION
## Summary
- Switch agronomist map base layer to Esri World Imagery satellite tiles
- Remove references to MBTiles/offline layer

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden installing @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68aef89f8490832ebe8e2dd02b7636ef