### PR TITLE
Persist agronomist data to Firestore

### DIFF
--- a/public/js/stores/agendaStore.js
+++ b/public/js/stores/agendaStore.js
@@ -1,3 +1,6 @@
+import { db } from '../config/firebase.js';
+import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+
 const KEY = 'agro.agenda';
 
 export function getAgenda() {
@@ -12,6 +15,9 @@ export function addAgenda(item) {
   };
   agenda.push(newItem);
   localStorage.setItem(KEY, JSON.stringify(agenda));
+  setDoc(doc(db, 'agenda', newItem.id), newItem).catch((err) =>
+    console.error('Erro ao salvar item da agenda no Firestore', err)
+  );
   return newItem;
 }
 
@@ -25,6 +31,9 @@ export function updateAgenda(id, changes) {
       updatedAt: new Date().toISOString(),
     };
     localStorage.setItem(KEY, JSON.stringify(agenda));
+    setDoc(doc(db, 'agenda', id), agenda[idx], { merge: true }).catch((err) =>
+      console.error('Erro ao atualizar item da agenda no Firestore', err)
+    );
     return agenda[idx];
   }
   return null;

--- a/public/js/stores/clientsStore.js
+++ b/public/js/stores/clientsStore.js
@@ -1,3 +1,6 @@
+import { db } from '../config/firebase.js';
+import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+
 const KEY = 'agro.clients';
 
 export function getClients() {
@@ -15,5 +18,9 @@ export function addClient(client) {
   };
   clients.push(newClient);
   localStorage.setItem(KEY, JSON.stringify(clients));
+  // Persistir no Firestore
+  setDoc(doc(db, 'clients', newClient.id), newClient).catch((err) =>
+    console.error('Erro ao salvar cliente no Firestore', err)
+  );
   return newClient;
 }

--- a/public/js/stores/leadsStore.js
+++ b/public/js/stores/leadsStore.js
@@ -1,3 +1,6 @@
+import { db } from '../config/firebase.js';
+import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+
 const KEY = 'agro.leads';
 
 export function getLeads() {
@@ -20,6 +23,10 @@ export function addLead(lead) {
   };
   leads.push(newLead);
   localStorage.setItem(KEY, JSON.stringify(leads));
+  // Persistir no Firestore
+  setDoc(doc(db, 'leads', newLead.id), newLead).catch((err) =>
+    console.error('Erro ao salvar lead no Firestore', err)
+  );
   return newLead;
 }
 
@@ -29,6 +36,9 @@ export function updateLead(id, changes) {
   if (idx >= 0) {
     leads[idx] = { ...leads[idx], ...changes, updatedAt: new Date().toISOString() };
     localStorage.setItem(KEY, JSON.stringify(leads));
+    setDoc(doc(db, 'leads', id), leads[idx], { merge: true }).catch((err) =>
+      console.error('Erro ao atualizar lead no Firestore', err)
+    );
     return leads[idx];
   }
   return null;

--- a/public/js/stores/propertiesStore.js
+++ b/public/js/stores/propertiesStore.js
@@ -1,3 +1,6 @@
+import { db } from '../config/firebase.js';
+import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+
 const KEY = 'agro.properties';
 
 export function getProperties() {
@@ -15,5 +18,8 @@ export function addProperty(property) {
   };
   props.push(newProp);
   localStorage.setItem(KEY, JSON.stringify(props));
+  setDoc(doc(db, 'properties', newProp.id), newProp).catch((err) =>
+    console.error('Erro ao salvar propriedade no Firestore', err)
+  );
   return newProp;
 }

--- a/public/js/stores/salesStore.js
+++ b/public/js/stores/salesStore.js
@@ -1,3 +1,6 @@
+import { db } from '../config/firebase.js';
+import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+
 const KEY = 'agro.sales';
 
 export function getSales() {
@@ -14,6 +17,9 @@ export function addSale(sale) {
   };
   sales.push(newSale);
   localStorage.setItem(KEY, JSON.stringify(sales));
+  setDoc(doc(db, 'sales', newSale.id), newSale).catch((err) =>
+    console.error('Erro ao salvar venda no Firestore', err)
+  );
   return newSale;
 }
 

--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -1,3 +1,6 @@
+import { db } from '../config/firebase.js';
+import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+
 const KEY = 'agro.visits';
 
 export function getVisits() {
@@ -12,5 +15,8 @@ export function addVisit(visit) {
   };
   visits.push(newVisit);
   localStorage.setItem(KEY, JSON.stringify(visits));
+  setDoc(doc(db, 'visits', newVisit.id), newVisit).catch((err) =>
+    console.error('Erro ao salvar visita no Firestore', err)
+  );
   return newVisit;
 }


### PR DESCRIPTION
## Summary
- Save clients, leads, visits, agenda items, properties and sales to Firestore when created or updated

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68aefd73e9ac832e9a75bed9997c90d2