### PR TITLE
sync clients and leads from firestore

### DIFF
--- a/public/js/services/auth.js
+++ b/public/js/services/auth.js
@@ -30,6 +30,8 @@ import { initOperadorTarefas } from '../pages/operador-tarefas.js';
 import { initOperadorAgenda } from '../pages/operador-agenda.js';
 import { initOperadorPerfil } from '../pages/operador-perfil.js';
 import { showLoader, hideLoader } from './ui.js';
+import { syncClientsFromFirestore } from '../stores/clientsStore.js';
+import { syncLeadsFromFirestore } from '../stores/leadsStore.js';
 
 // ===== Detectores robustos de "tela de login" e redirect seguro =====
 function isLoginRoute() {
@@ -221,7 +223,12 @@ document.addEventListener('DOMContentLoaded', () => {
                             await logout();
                         }
                     } else {
-                        console.log('[auth] usuário autenticado, inicializando página', userRole);
+                        console.log('[auth] usuário autenticado, sincronizando dados locais');
+                        await Promise.all([
+                          syncClientsFromFirestore(),
+                          syncLeadsFromFirestore(),
+                        ]);
+                        console.log('[auth] dados sincronizados, inicializando página', userRole);
                         initializePage(user, userRole);
                     }
                 } else {

--- a/public/js/stores/clientsStore.js
+++ b/public/js/stores/clientsStore.js
@@ -1,5 +1,10 @@
 import { db } from '../config/firebase.js';
-import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+import {
+  doc,
+  setDoc,
+  collection,
+  getDocs,
+} from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 
 const KEY = 'agro.clients';
 
@@ -23,4 +28,16 @@ export function addClient(client) {
     console.error('Erro ao salvar cliente no Firestore', err)
   );
   return newClient;
+}
+
+export async function syncClientsFromFirestore() {
+  try {
+    const snap = await getDocs(collection(db, 'clients'));
+    const clients = snap.docs.map((d) => d.data());
+    localStorage.setItem(KEY, JSON.stringify(clients));
+    return clients;
+  } catch (err) {
+    console.error('Erro ao buscar clientes do Firestore', err);
+    return [];
+  }
 }

--- a/public/js/stores/leadsStore.js
+++ b/public/js/stores/leadsStore.js
@@ -1,5 +1,10 @@
 import { db } from '../config/firebase.js';
-import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+import {
+  doc,
+  setDoc,
+  collection,
+  getDocs,
+} from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 
 const KEY = 'agro.leads';
 
@@ -42,4 +47,16 @@ export function updateLead(id, changes) {
     return leads[idx];
   }
   return null;
+}
+
+export async function syncLeadsFromFirestore() {
+  try {
+    const snap = await getDocs(collection(db, 'leads'));
+    const leads = snap.docs.map((d) => d.data());
+    localStorage.setItem(KEY, JSON.stringify(leads));
+    return leads;
+  } catch (err) {
+    console.error('Erro ao buscar leads do Firestore', err);
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- add Firestore sync helpers for clients and leads stores
- load clients and leads from Firestore during auth

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af029b524c832e9c41ed4d1399f560