### PR TITLE
fix: prevent undefined fields in visits

### DIFF
--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -3,16 +3,22 @@ import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-f
 
 const KEY = 'agro.visits';
 
+function removeUndefinedFields(obj) {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined)
+  );
+}
+
 export function getVisits() {
   return JSON.parse(localStorage.getItem(KEY) || '[]');
 }
 
 export function addVisit(visit) {
   const visits = getVisits();
-  const newVisit = {
+  const newVisit = removeUndefinedFields({
     id: Date.now().toString(36),
     ...visit
-  };
+  });
   visits.push(newVisit);
   localStorage.setItem(KEY, JSON.stringify(visits));
   setDoc(doc(db, 'visits', newVisit.id), newVisit).catch((err) =>
@@ -25,7 +31,7 @@ export function updateVisit(id, changes) {
   const visits = getVisits();
   const idx = visits.findIndex((v) => v.id === id);
   if (idx >= 0) {
-    visits[idx] = { ...visits[idx], ...changes };
+    visits[idx] = removeUndefinedFields({ ...visits[idx], ...changes });
     localStorage.setItem(KEY, JSON.stringify(visits));
     setDoc(doc(db, 'visits', id), visits[idx], { merge: true }).catch((err) =>
       console.error('Erro ao atualizar visita no Firestore', err)


### PR DESCRIPTION
## Summary
- sanitize visit objects before saving to Firestore and localStorage to avoid undefined field errors

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af1286f208832eacc1c8250092472c