### PR TITLE
Replace prompt popups with modals

### DIFF
--- a/public/js/pages/client-details.js
+++ b/public/js/pages/client-details.js
@@ -7,6 +7,7 @@
 
 import { getLeads } from '../stores/leadsStore.js';
 import { getVisits, updateVisit } from '../stores/visitsStore.js';
+import { promptModal } from '../services/ui.js';
 
 export function initClientDetails(userId, userRole) {
   const params = new URLSearchParams(window.location.search);
@@ -107,13 +108,16 @@ export function initClientDetails(userId, userRole) {
     });
   }
 
-  historyTimeline?.addEventListener('click', (e) => {
+  historyTimeline?.addEventListener('click', async (e) => {
     const btn = e.target.closest('.edit-visit');
     if (!btn) return;
     const visitId = btn.dataset.id;
     const visit = getVisits().find((v) => v.id === visitId);
     if (!visit) return;
-    const newText = prompt('Editar texto da visita', visit.notes || '');
+    const newText = await promptModal({
+      title: 'Editar texto da visita',
+      initialValue: visit.notes || '',
+    });
     if (newText === null) return;
     updateVisit(visitId, { notes: newText.trim() });
     loadVisits();
@@ -167,7 +171,10 @@ export function initClientDetails(userId, userRole) {
 
   // --- Adiciona nova propriedade -----------------------------------------
   async function addProperty() {
-    const name = prompt('Nome da propriedade');
+    const name = await promptModal({
+      title: 'Nome da propriedade',
+      multiline: false,
+    });
     if (!name) return;
 
     try {

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -1,6 +1,6 @@
 import { initBottomNav, bindPlus, toggleModal } from './agro-bottom-nav.js';
 import { getCurrentPositionSafe } from '../utils/geo.js';
-import { showToast } from '../services/ui.js';
+import { showToast, promptModal } from '../services/ui.js';
 import { db, auth } from '../config/firebase.js';
 import {
   collection,
@@ -151,13 +151,16 @@ export function initAgronomoDashboard(userId, userRole) {
     historyFilterAll?.addEventListener('click', () => setHistoryFilter('all'));
     historyFilterVisits?.addEventListener('click', () => setHistoryFilter('visits'));
     historyFilterAdds?.addEventListener('click', () => setHistoryFilter('adds'));
-    historyTimeline?.addEventListener('click', (e) => {
+    historyTimeline?.addEventListener('click', async (e) => {
       const btn = e.target.closest('.edit-visit');
       if (!btn) return;
       const visitId = btn.dataset.id;
       const visit = getVisits().find((v) => v.id === visitId);
       if (!visit) return;
-      const newText = prompt('Editar texto da visita', visit.notes || '');
+      const newText = await promptModal({
+        title: 'Editar texto da visita',
+        initialValue: visit.notes || '',
+      });
       if (newText === null) return;
       updateVisit(visitId, { notes: newText.trim() });
       renderHistory();

--- a/public/js/pages/lead-details.js
+++ b/public/js/pages/lead-details.js
@@ -16,7 +16,7 @@ import {
   serverTimestamp,
   Timestamp
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
-import { showToast, showSpinner, hideSpinner } from '../services/ui.js';
+import { showToast, showSpinner, hideSpinner, promptModal } from '../services/ui.js';
 
 export function initLeadDetails(userId, userRole) {
   const params = new URLSearchParams(window.location.search);
@@ -265,7 +265,10 @@ export function initLeadDetails(userId, userRole) {
       getVisits().find((v) => v.id === visitId);
     if (!visit) return;
     const currentText = visit.summary ?? visit.notes ?? '';
-    const newText = prompt('Editar texto da visita', currentText);
+    const newText = await promptModal({
+      title: 'Editar texto da visita',
+      initialValue: currentText,
+    });
     if (newText === null) return;
     try {
       if (usingLocalData) {

--- a/public/js/services/ui.js
+++ b/public/js/services/ui.js
@@ -156,3 +156,68 @@ export function closeModal(modalElement) {
         modalElement.classList.add('hidden');
     }
 }
+
+/**
+ * Exibe um modal com campo de texto e retorna o valor informado.
+ * @param {Object} opts
+ * @param {string} opts.title - Título exibido no modal.
+ * @param {string} [opts.initialValue=''] - Valor inicial do campo.
+ * @param {boolean} [opts.multiline=true] - Usa textarea quando verdadeiro.
+ * @returns {Promise<string|null>} Valor digitado ou null se cancelado.
+ */
+export function promptModal({
+    title,
+    initialValue = '',
+    multiline = true,
+} = {}) {
+    return new Promise((resolve) => {
+        const modal = document.createElement('div');
+        modal.className = 'modal hidden';
+        modal.innerHTML = `
+      <div class="modal-card w-full max-w-md">
+        ${title ? `<h3 class="font-semibold mb-4">${title}</h3>` : ''}
+        <form class="grid gap-4">
+          <div class="field">
+            ${multiline
+                ? `<textarea class="input" rows="4">${initialValue}</textarea>`
+                : `<input class="input" value="${initialValue}" />`}
+          </div>
+          <div class="flex gap-2 justify-end">
+            <button type="button" class="btn-secondary">Cancelar</button>
+            <button type="submit" class="btn-primary">Salvar</button>
+          </div>
+        </form>
+      </div>`;
+
+        document.body.appendChild(modal);
+
+        const input = modal.querySelector(multiline ? 'textarea' : 'input');
+        const form = modal.querySelector('form');
+        const btnCancel = modal.querySelector('button[type="button"]');
+
+        function close(result) {
+            modal.remove();
+            document.removeEventListener('keydown', onKeyDown);
+            resolve(result);
+        }
+
+        function onKeyDown(e) {
+            if (e.key === 'Escape') {
+                close(null);
+            }
+        }
+
+        btnCancel.addEventListener('click', () => close(null));
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            close(input.value);
+        });
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) close(null);
+        });
+        document.addEventListener('keydown', onKeyDown);
+
+        modal.classList.remove('hidden');
+        input.focus();
+    });
+}


### PR DESCRIPTION
## Summary
- add reusable `promptModal` helper for consistent text input
- use modals to edit visit notes across agronomist pages
- use modal to name new properties instead of browser prompt

## Testing
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af14ba7ffc832e99ca2fd4e07a5bf9