### PR TITLE
feat: persist auth session

### DIFF
--- a/public/js/config/Livefirebase.js
+++ b/public/js/config/Livefirebase.js
@@ -2,7 +2,7 @@
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-app.js';
 // REMOVIDO 'enablePersistence' desta importação, pois não é exportado por este bundle CDN
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
-import { getAuth } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-auth.js';
+import { getAuth, setPersistence, browserLocalPersistence } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-auth.js';
 import { getMessaging } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
 
 // Seu objeto de configuração do Firebase (substitua com suas chaves reais!)
@@ -20,6 +20,10 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app); // Inicializa o Auth aqui
+
+// Garante que a autenticação persista entre sessões do navegador
+setPersistence(auth, browserLocalPersistence)
+  .catch(err => console.error('Erro ao configurar persistência:', err));
 
 let messaging;
 try {

--- a/public/js/config/firebase.js
+++ b/public/js/config/firebase.js
@@ -2,7 +2,7 @@
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-app.js';
 // REMOVIDO 'enablePersistence' desta importação, pois não é exportado por este bundle CDN
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
-import { getAuth } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-auth.js';
+import { getAuth, setPersistence, browserLocalPersistence } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-auth.js';
 import { getMessaging } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
 
 // Seu objeto de configuração do Firebase (substitua com suas chaves reais!)
@@ -19,6 +19,10 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app); // Inicializa o Auth aqui
+
+// Garante que a autenticação persista entre sessões do navegador
+setPersistence(auth, browserLocalPersistence)
+  .catch(err => console.error('Erro ao configurar persistência:', err));
 
 let messaging;
 try {


### PR DESCRIPTION
## Summary
- keep Firebase Auth sessions across browser restarts using `browserLocalPersistence`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2b981650832e85ddf3ce2808c1a7