### PR TITLE
Enable Firestore offline persistence

### DIFF
--- a/public/js/config/firebase.js
+++ b/public/js/config/firebase.js
@@ -1,7 +1,7 @@
 // public/js/config/firebase.js
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-app.js';
 // REMOVIDO 'enablePersistence' desta importação, pois não é exportado por este bundle CDN
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
+import { getFirestore, enableIndexedDbPersistence } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 import { getAuth, setPersistence, browserLocalPersistence } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-auth.js';
 import { getMessaging } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging.js';
 
@@ -32,20 +32,16 @@ try {
   console.warn('Firebase messaging não suportado neste ambiente.', err);
 }
 
-// O BLOCO ABAIXO FOI COMENTADO PARA RESOLVER O ERRO DE IMPORTAÇÃO
-// Se a persistência offline for crucial, você precisará investigar a forma correta
-// de importá-la para a versão 9.6.0 via CDN, ou usar um bundler (webpack/rollup).
-/*
-enablePersistence(db)
+// Ativa persistência offline do Firestore para permitir uso sem conexão
+enableIndexedDbPersistence(db)
   .catch((err) => {
-      if (err.code == 'failed-precondition') {
-          console.warn("Persistence failed: Can't enable persistence because multiple tabs are open or another instance is active.");
-      } else if (err.code == 'unimplemented') {
-          console.warn("Persistence failed: Current browser does not support persistence.");
-      } else {
-          console.error("Persistence failed for unknown reason:", err);
-      }
+    if (err.code === 'failed-precondition') {
+      console.warn("Persistence failed: Can't enable persistence because multiple tabs are open or another instance is active.");
+    } else if (err.code === 'unimplemented') {
+      console.warn("Persistence failed: Current browser does not support persistence.");
+    } else {
+      console.error("Persistence failed for unknown reason:", err);
+    }
   });
-*/
 
 export { db, app, auth, messaging }; // Exportar 'db', 'app', 'auth' e utilitários de messaging


### PR DESCRIPTION
## Summary
- import `enableIndexedDbPersistence` from Firestore CDN
- activate Firestore offline persistence so data works without internet

## Testing
- `npm test` *(fails: vitest not found)*
- `npx --yes vitest@1.5.2 run` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68af33f683b0832e9fa6dd6aeb3bd5f0