### PR TITLE
Persist visits to Firebase

### DIFF
--- a/public/js/pages/client-details.js
+++ b/public/js/pages/client-details.js
@@ -82,9 +82,9 @@ export function initClientDetails(userId, userRole) {
     document.getElementById('propertiesSection')?.classList.add('hidden');
   }
 
-  function loadVisits() {
+  async function loadVisits() {
     if (!historyTimeline) return;
-    const visits = getVisits().filter(
+    const visits = (await getVisits()).filter(
       (v) => v.refId === id && v.type === (isLead ? 'lead' : 'cliente')
     );
     if (!visits.length) {
@@ -112,15 +112,15 @@ export function initClientDetails(userId, userRole) {
     const btn = e.target.closest('.edit-visit');
     if (!btn) return;
     const visitId = btn.dataset.id;
-    const visit = getVisits().find((v) => v.id === visitId);
+    const visit = (await getVisits()).find((v) => v.id === visitId);
     if (!visit) return;
     const newText = await promptModal({
       title: 'Editar texto da visita',
       initialValue: visit.notes || '',
     });
     if (newText === null) return;
-    updateVisit(visitId, { notes: newText.trim() });
-    loadVisits();
+    await updateVisit(visitId, { notes: newText.trim() });
+    await loadVisits();
   });
 
   // --- Lista propriedades -------------------------------------------------

--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -1,7 +1,11 @@
 import { db } from '../config/firebase.js';
-import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
-
-const KEY = 'agro.visits';
+import {
+  collection,
+  getDocs,
+  addDoc,
+  doc,
+  updateDoc
+} from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 
 function removeUndefinedFields(obj) {
   return Object.fromEntries(
@@ -9,34 +13,21 @@ function removeUndefinedFields(obj) {
   );
 }
 
-export function getVisits() {
-  return JSON.parse(localStorage.getItem(KEY) || '[]');
+export async function getVisits() {
+  const snap = await getDocs(collection(db, 'visits'));
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 }
 
-export function addVisit(visit) {
-  const visits = getVisits();
-  const newVisit = removeUndefinedFields({
-    id: Date.now().toString(36),
+export async function addVisit(visit) {
+  const clean = removeUndefinedFields({
     ...visit
   });
-  visits.push(newVisit);
-  localStorage.setItem(KEY, JSON.stringify(visits));
-  setDoc(doc(db, 'visits', newVisit.id), newVisit).catch((err) =>
-    console.error('Erro ao salvar visita no Firestore', err)
-  );
-  return newVisit;
+  const ref = await addDoc(collection(db, 'visits'), clean);
+  return { id: ref.id, ...clean };
 }
 
-export function updateVisit(id, changes) {
-  const visits = getVisits();
-  const idx = visits.findIndex((v) => v.id === id);
-  if (idx >= 0) {
-    visits[idx] = removeUndefinedFields({ ...visits[idx], ...changes });
-    localStorage.setItem(KEY, JSON.stringify(visits));
-    setDoc(doc(db, 'visits', id), visits[idx], { merge: true }).catch((err) =>
-      console.error('Erro ao atualizar visita no Firestore', err)
-    );
-    return visits[idx];
-  }
-  return null;
+export async function updateVisit(id, changes) {
+  const clean = removeUndefinedFields(changes);
+  await updateDoc(doc(db, 'visits', id), clean);
+  return { id, ...clean };
 }

--- a/public/js/utils/metrics.js
+++ b/public/js/utils/metrics.js
@@ -1,8 +1,8 @@
 import { getVisits } from '../stores/visitsStore.js';
 import { getSales } from '../stores/salesStore.js';
 
-export function countVisitsLast30d() {
-  const visits = getVisits();
+export async function countVisitsLast30d() {
+  const visits = await getVisits();
   const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
   return visits.filter((v) => {
     const at = new Date(v.at).getTime();


### PR DESCRIPTION
## Summary
- Replace localStorage-based visit store with Firestore-backed asynchronous API
- Update dashboard and detail pages to load and edit visits directly from Firestore
- Adjust metrics to count visits using the Firestore data

## Testing
- `npx vitest run` (fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)


------
https://chatgpt.com/codex/tasks/task_e_68af57c9f68c832e86effa5bc7885ca2