### PR TITLE
feat: cache visits locally

### DIFF
--- a/public/js/pages/client-details.js
+++ b/public/js/pages/client-details.js
@@ -84,7 +84,8 @@ export function initClientDetails(userId, userRole) {
 
   async function loadVisits() {
     if (!historyTimeline) return;
-    const visits = (await getVisits()).filter(
+    const allVisits = await getVisits();
+    const visits = allVisits.filter(
       (v) => v.refId === id && v.type === (isLead ? 'lead' : 'cliente')
     );
     if (!visits.length) {
@@ -112,7 +113,8 @@ export function initClientDetails(userId, userRole) {
     const btn = e.target.closest('.edit-visit');
     if (!btn) return;
     const visitId = btn.dataset.id;
-    const visit = (await getVisits()).find((v) => v.id === visitId);
+    const allVisits = await getVisits();
+    const visit = allVisits.find((v) => v.id === visitId);
     if (!visit) return;
     const newText = await promptModal({
       title: 'Editar texto da visita',

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -87,7 +87,8 @@ export function initAgronomoDashboard(userId, userRole) {
 
   async function renderHistory() {
     if (!historyTimeline) return;
-    const visits = (await getVisits()).map((v) => ({
+    const visitList = await getVisits();
+    const visits = visitList.map((v) => ({
       id: v.id,
       type: 'visit',
       at: v.at,
@@ -155,7 +156,8 @@ export function initAgronomoDashboard(userId, userRole) {
       const btn = e.target.closest('.edit-visit');
       if (!btn) return;
       const visitId = btn.dataset.id;
-      const visit = (await getVisits()).find((v) => v.id === visitId);
+      const allVisits = await getVisits();
+      const visit = allVisits.find((v) => v.id === visitId);
       if (!visit) return;
       const newText = await promptModal({
         title: 'Editar texto da visita',
@@ -396,12 +398,12 @@ export function initAgronomoDashboard(userId, userRole) {
     const clients = getClients();
     const properties = getProperties();
     const leads = getLeads().filter((l) => l.stage !== 'Convertido');
-    const visits = await getVisits();
+    const visitList = await getVisits();
     let items = [];
     items.push(
       ...clients.map((c) => {
         const prop = properties.find((p) => p.clientId === c.id);
-        const vList = visits.filter(
+        const vList = visitList.filter(
           (vi) => vi.type === 'cliente' && vi.refId === c.id
         );
         const last = vList.sort((a, b) => new Date(b.at) - new Date(a.at))[0];
@@ -416,7 +418,7 @@ export function initAgronomoDashboard(userId, userRole) {
     );
     items.push(
       ...leads.map((l) => {
-        const vList = visits.filter(
+        const vList = visitList.filter(
           (vi) => vi.type === 'lead' && vi.refId === l.id
         );
         const last = vList.sort((a, b) => new Date(b.at) - new Date(a.at))[0];
@@ -558,9 +560,9 @@ export function initAgronomoDashboard(userId, userRole) {
     const search =
       document.getElementById('leadsSearch')?.value.toLowerCase().trim() || '';
     const leads = getLeads().filter((l) => l.stage !== 'Convertido');
-    const visits = await getVisits();
+    const visitList = await getVisits();
     let items = leads.map((l) => {
-      const vList = visits.filter((v) => v.type === 'lead' && v.refId === l.id);
+      const vList = visitList.filter((v) => v.type === 'lead' && v.refId === l.id);
       const last = vList.sort((a, b) => new Date(b.at) - new Date(a.at))[0];
       return {
         lead: l,
@@ -1001,7 +1003,8 @@ export function initAgronomoDashboard(userId, userRole) {
       document.getElementById('kpiSales').textContent = String(salesTons);
 
       const visitsCut = now.getTime() - 28 * 24 * 60 * 60 * 1000;
-      const visitsCount = (await getVisits()).filter((v) => {
+      const allVisits = await getVisits();
+      const visitsCount = allVisits.filter((v) => {
         const t = new Date(v.at).getTime();
         return !isNaN(t) && t >= visitsCut;
       }).length;
@@ -1149,7 +1152,8 @@ export function initAgronomoDashboard(userId, userRole) {
     }
     const weeks = weekLabels();
     const map = new Map(weeks.map((w) => [w.key, 0]));
-    (await getVisits()).forEach((v) => {
+    const allVisits = await getVisits();
+    allVisits.forEach((v) => {
       const d = new Date(v.at);
       const key = `${d.getFullYear()}-${getISOWeek(d)}`;
       if (map.has(key)) map.set(key, map.get(key) + 1);

--- a/public/js/pages/lead-details.js
+++ b/public/js/pages/lead-details.js
@@ -96,8 +96,8 @@ export function initLeadDetails(userId, userRole) {
     currentLeadData = lead;
     if (visitsTimeline) {
       hideSpinner(visitsTimeline);
-      const all = await getVisits();
-      visitsCache = all.filter(
+      const allVisits = await getVisits();
+      visitsCache = allVisits.filter(
         (v) => v.refId === leadId && v.type === 'lead'
       );
       if (!visitsCache.length) {
@@ -262,8 +262,10 @@ export function initLeadDetails(userId, userRole) {
     const btn = e.target.closest('.edit-visit');
     if (!btn) return;
     const visitId = btn.dataset.id;
-    const visit = visitsCache.find((v) => v.id === visitId) ||
-      (await getVisits()).find((v) => v.id === visitId);
+    const localVisits = await getVisits();
+    const visit =
+      visitsCache.find((v) => v.id === visitId) ||
+      localVisits.find((v) => v.id === visitId);
     if (!visit) return;
     const currentText = visit.summary ?? visit.notes ?? '';
     const newText = await promptModal({

--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -7,27 +7,106 @@ import {
   updateDoc
 } from 'https://www.gstatic.com/firebasejs/9.6.0/firebase-firestore.js';
 
+const KEY = 'agro.visits';
+
+function readLocal() {
+  return JSON.parse(localStorage.getItem(KEY) || '[]');
+}
+
+function saveLocal(data) {
+  localStorage.setItem(KEY, JSON.stringify(data));
+}
+
 function removeUndefinedFields(obj) {
-  return Object.fromEntries(
-    Object.entries(obj).filter(([, value]) => value !== undefined)
-  );
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined));
+}
+
+function isTempId(id) {
+  return id.startsWith('local-');
 }
 
 export async function getVisits() {
-  const snap = await getDocs(collection(db, 'visits'));
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  const local = readLocal();
+  if (navigator.onLine) {
+    for (const v of local.filter((v) => !v.synced)) {
+      const { synced, ...data } = v;
+      try {
+        if (isTempId(v.id)) {
+          const ref = await addDoc(collection(db, 'visits'), removeUndefinedFields(data));
+          v.id = ref.id;
+        } else {
+          await updateDoc(doc(db, 'visits', v.id), removeUndefinedFields(data));
+        }
+        v.synced = true;
+      } catch (err) {
+        console.error('Erro ao sincronizar visita', err);
+      }
+    }
+    saveLocal(local);
+    try {
+      const snap = await getDocs(collection(db, 'visits'));
+      const remote = snap.docs.map((d) => ({ id: d.id, ...d.data(), synced: true }));
+      saveLocal(remote);
+      return remote;
+    } catch (err) {
+      console.error('Erro ao buscar visitas do Firestore', err);
+      return local;
+    }
+  }
+  return local;
 }
 
 export async function addVisit(visit) {
-  const clean = removeUndefinedFields({
-    ...visit
-  });
-  const ref = await addDoc(collection(db, 'visits'), clean);
-  return { id: ref.id, ...clean };
+  const visits = readLocal();
+  const newVisit = {
+    id: `local-${Date.now().toString(36)}`,
+    at: new Date().toISOString(),
+    ...visit,
+    synced: navigator.onLine
+  };
+  visits.push(newVisit);
+  saveLocal(visits);
+
+  if (navigator.onLine) {
+    try {
+      const { synced, id, ...data } = newVisit;
+      const ref = await addDoc(collection(db, 'visits'), removeUndefinedFields(data));
+      const idx = visits.findIndex((v) => v.id === id);
+      if (idx >= 0) {
+        visits[idx] = { id: ref.id, ...data, synced: true };
+        saveLocal(visits);
+        return visits[idx];
+      }
+      return { id: ref.id, ...data, synced: true };
+    } catch (err) {
+      console.error('Erro ao adicionar visita no Firestore', err);
+    }
+  }
+  return newVisit;
 }
 
 export async function updateVisit(id, changes) {
-  const clean = removeUndefinedFields(changes);
-  await updateDoc(doc(db, 'visits', id), clean);
-  return { id, ...clean };
+  const visits = readLocal();
+  const idx = visits.findIndex((v) => v.id === id);
+  if (idx >= 0) {
+    visits[idx] = {
+      ...visits[idx],
+      ...changes,
+      synced: navigator.onLine ? true : false
+    };
+    saveLocal(visits);
+  }
+
+  if (navigator.onLine) {
+    try {
+      await updateDoc(doc(db, 'visits', id), removeUndefinedFields(changes));
+      if (idx >= 0) {
+        visits[idx].synced = true;
+        saveLocal(visits);
+      }
+    } catch (err) {
+      console.error('Erro ao atualizar visita no Firestore', err);
+    }
+  }
+  return idx >= 0 ? visits[idx] : null;
 }


### PR DESCRIPTION
## Summary
- persist visits in localStorage and sync with Firestore when online
- adapt pages to consume locally cached visits

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_68af5afaad68832e92efe2a98ef5506b