### PR TITLE
Fix duplicate offline visit sync and mobile text justification

### DIFF
--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -36,8 +36,10 @@ export async function getVisits() {
   // Normalize different visit schemas into a common shape
   const normalize = (docSnap) => {
     const data = docSnap.data ? docSnap.data() : docSnap;
-    // Prefer full ref path when available for uniqueness
-    const stableId = docSnap.ref?.path || docSnap.path || docSnap.id || data.id;
+    // Use visitId when available to deduplicate top-level and subcollection records
+    // Fallback to document id or full path for legacy entries
+    const stableId =
+      data.visitId || docSnap.id || docSnap.ref?.path || docSnap.path || data.id;
 
     // Author: accept authorId or agronomistId
     const authorId = data.authorId || data.agronomistId || null;

--- a/public/style.css
+++ b/public/style.css
@@ -145,6 +145,10 @@ letter-spacing: normal;
     word-spacing: normal;
 }
 
+@media (max-width:480px){
+  p{text-align:justify;}
+}
+
 /* Fundo da página de login com imagem LOCAL */
 .login-background {
     background-image: url('background.jpg');


### PR DESCRIPTION
## Summary
- prevent repeated visit entries by deduplicating using visitId
- justify paragraph text on small screens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e3bcec58832e9fd6f1d1e1925cfb