### PR TITLE
Fix visit modal closure and prevent horizontal scroll

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -954,10 +954,10 @@ export function initAgronomoDashboard(userId, userRole) {
         : 'Sem internet: visita salva e será sincronizada.',
       saved.synced ? 'success' : 'info'
     );
-    if (location.hash === '#historico') await renderHistory();
     toggleModal(visitModal, false);
     clearErrors(form);
     form.reset();
+    if (location.hash === '#historico') await renderHistory();
     renderLeadsList();
     renderContactsList();
     renderHomeKPIs();

--- a/public/style.css
+++ b/public/style.css
@@ -54,7 +54,7 @@
 }
 
 .hidden{display:none !important;}
-html,body{-webkit-text-size-adjust:100%;text-size-adjust:100%;}
+html,body{margin:0;overflow-x:hidden;-webkit-text-size-adjust:100%;text-size-adjust:100%;}
 .page-container{
   max-width:1200px;
   margin:0 auto;


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling by hiding body overflow
- close visit modal immediately after saving and showing sync message

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e90e7e88832ea75e20e6f0a8916f