### PR TITLE
Add offline agronomist dashboard with export/import tools

### DIFF
--- a/agronomooffline/index.html
+++ b/agronomooffline/index.html
@@ -4,17 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#166534" />
-  <link rel="icon" type="image/png" href="/favicon.png" />
-  <link rel="manifest" href="/manifest.json" />
-  <link rel="modulepreload" href="/vendor/firebase/9.6.0/firebase-app.js" crossorigin>
-  <link rel="modulepreload" href="/vendor/firebase/9.6.0/firebase-auth.js" crossorigin>
-  <link rel="modulepreload" href="/vendor/firebase/9.6.0/firebase-firestore.js" crossorigin>
-  <link rel="modulepreload" href="/vendor/firebase/9.6.1/firebase-messaging.js" crossorigin>
+  <base href="../public/" />
+  <link rel="icon" type="image/png" href="favicon.png" />
+  <link rel="manifest" href="manifest.json" />
+  <link rel="modulepreload" href="vendor/firebase/9.6.0/firebase-app.js" crossorigin>
+  <link rel="modulepreload" href="vendor/firebase/9.6.0/firebase-auth.js" crossorigin>
+  <link rel="modulepreload" href="vendor/firebase/9.6.0/firebase-firestore.js" crossorigin>
+  <link rel="modulepreload" href="vendor/firebase/9.6.1/firebase-messaging.js" crossorigin>
   <script type="module" src="js/app.js"></script>
-  <script src="/vendor/tailwind/tailwind.js"></script>
+  <script src="vendor/tailwind/tailwind.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
-  <link rel="stylesheet" href="/vendor/leaflet/leaflet.css" />
-  <script src="/vendor/leaflet/leaflet.js" defer></script>
+  <link rel="stylesheet" href="vendor/leaflet/leaflet.css" />
+  <script src="vendor/leaflet/leaflet.js" defer></script>
   <link rel="stylesheet" href="style.css" />
   <title>Orgânia - Painel do Agrônomo</title>
 </head>
@@ -25,7 +26,9 @@
     <div class="px-4 py-3 flex justify-between items-center">
       <h1 class="text-lg font-bold" style="color: var(--brand-green);">Painel do Agrônomo</h1>
       <div class="flex items-center space-x-2">
-        <button id="exportOfflineBtn" class="px-3 py-1.5 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 text-sm">Exportar</button>
+        <input type="file" id="importOfflineInput" class="hidden" />
+        <button id="importOfflineBtn" class="px-3 py-1.5 bg-gray-600 text-white font-semibold rounded-lg hover:bg-gray-700 text-sm">Importar</button>
+        <button id="exportFirebaseBtn" class="px-3 py-1.5 bg-emerald-600 text-white font-semibold rounded-lg hover:bg-emerald-700 text-sm">Exportar</button>
         <button onclick="logout()" class="px-3 py-1.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 text-sm">Sair</button>
       </div>
     </div>
@@ -459,12 +462,9 @@
     </div>
   </div>
 
-  <script src="/__/firebase/9.6.1/firebase-app-compat.js"></script>
-  <script src="/__/firebase/9.6.1/firebase-auth-compat.js"></script>
-  <script src="/__/firebase/9.6.1/firebase-firestore-compat.js"></script>
-  <script src="/__/firebase/init.js"></script>
   <script type="module" src="js/services/auth.js"></script>
-  <script src="/vendor/chart/chart.umd.js" defer></script>
+  <script src="vendor/chart/chart.umd.js" defer></script>
   <script type="module" src="js/pages/dashboard-agronomo.js"></script>
+  <script type="module" src="../agronomooffline/offline.js"></script>
 </body>
 </html>

--- a/agronomooffline/offline.js
+++ b/agronomooffline/offline.js
@@ -1,0 +1,52 @@
+import { syncClientsFromFirestore } from '../public/js/stores/clientsStore.js';
+import { syncLeadsFromFirestore } from '../public/js/stores/leadsStore.js';
+import { syncAgendaFromFirestore } from '../public/js/stores/agendaStore.js';
+import { getVisits } from '../public/js/stores/visitsStore.js';
+
+function handleImport(file) {
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    try {
+      const data = JSON.parse(e.target.result);
+      if (data.clients) localStorage.setItem('agro.clients', JSON.stringify(data.clients));
+      if (data.leads) localStorage.setItem('agro.leads', JSON.stringify(data.leads));
+      if (data.agenda) localStorage.setItem('agro.agenda', JSON.stringify(data.agenda));
+      if (data.visits) localStorage.setItem('agro.visits', JSON.stringify(data.visits));
+      alert('Dados importados com sucesso.');
+    } catch (err) {
+      console.error('Falha ao importar', err);
+      alert('Falha ao importar dados.');
+    }
+  };
+  reader.readAsText(file);
+}
+
+async function exportToFirebase() {
+  if (!navigator.onLine) {
+    alert('Sem conexão.');
+    return;
+  }
+  try {
+    await Promise.all([
+      syncClientsFromFirestore(),
+      syncLeadsFromFirestore(),
+      syncAgendaFromFirestore(),
+      getVisits(),
+    ]);
+    alert('Exportado com sucesso.');
+  } catch (err) {
+    console.error('Erro ao exportar', err);
+    alert('Falha ao exportar.');
+  }
+}
+
+const importBtn = document.getElementById('importOfflineBtn');
+const importInput = document.getElementById('importOfflineInput');
+const exportBtn = document.getElementById('exportFirebaseBtn');
+
+importBtn?.addEventListener('click', () => importInput?.click());
+importInput?.addEventListener('change', (e) => {
+  const file = e.target.files?.[0];
+  if (file) handleImport(file);
+});
+exportBtn?.addEventListener('click', exportToFirebase);

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -38,6 +38,23 @@ export function initAgronomoDashboard(userId, userRole) {
   const leadVisitDate = document.getElementById('leadVisitDate');
   const leadVisitSummary = document.getElementById('leadVisitSummary');
   const leadVisitNotes = document.getElementById('leadVisitNotes');
+  const exportOfflineBtn = document.getElementById('exportOfflineBtn');
+
+  exportOfflineBtn?.addEventListener('click', async () => {
+    const data = {
+      clients: getClients(),
+      leads: getLeads(),
+      agenda: getAgenda(),
+      visits: await getVisits(),
+    };
+    const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'agronomo-data.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
   const leadVisitOutcome = document.getElementById('leadVisitOutcome');
   const leadVisitNextStep = document.getElementById('leadVisitNextStep');
   const leadVisitTaskEnable = document.getElementById('leadVisitTaskEnable');


### PR DESCRIPTION
## Summary
- add export button on agronomist dashboard to download local data
- introduce offline dashboard copy with import and firebase export scripts

## Testing
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b2f1d3bc68832e8b52e276126dd639