### PR TITLE
fix auth persistence fallback and handle localStorage quota

### DIFF
--- a/public/js/config/firebase.js
+++ b/public/js/config/firebase.js
@@ -1,7 +1,7 @@
 ﻿// public/js/config/firebase.js
 import { initializeApp } from '/vendor/firebase/9.6.0/firebase-app.js';
 import { getFirestore, enableIndexedDbPersistence } from '/vendor/firebase/9.6.0/firebase-firestore.js';
-import { getAuth, setPersistence, browserLocalPersistence, indexedDBLocalPersistence } from '/vendor/firebase/9.6.0/firebase-auth.js';
+import { getAuth, setPersistence, browserLocalPersistence, indexedDBLocalPersistence, inMemoryPersistence } from '/vendor/firebase/9.6.0/firebase-auth.js';
 import { getMessaging } from '/vendor/firebase/9.6.1/firebase-messaging.js';
 
 // Config do Firebase
@@ -23,6 +23,7 @@ const auth = getAuth(app);
 
 setPersistence(auth, indexedDBLocalPersistence)
   .catch(() => setPersistence(auth, browserLocalPersistence))
+  .catch(() => setPersistence(auth, inMemoryPersistence))
   .catch(() => {});
 
 // Inicializa Messaging quando suportado


### PR DESCRIPTION
## Summary
- fix indexedDB import and add offline auth persistence fallbacks
- guard visits localStorage writes to avoid quota crashes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest@^1.5.2` *(fails: 403 Forbidden to @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b46edafce4832eab6cd3a53b1ab72b