### PR TITLE
feat: offline visits storage with IndexedDB

### DIFF
--- a/public/js/lib/db/indexeddb.js
+++ b/public/js/lib/db/indexeddb.js
@@ -1,0 +1,49 @@
+const DB_NAME = 'agrodb';
+const DB_VERSION = 1;
+let dbPromise = null;
+
+export function getDB() {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains('visits')) {
+        db.createObjectStore('visits', { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains('outbox')) {
+        db.createObjectStore('outbox', { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onsuccess = (event) => resolve(event.target.result);
+    request.onerror = () => reject(request.error);
+  });
+  return dbPromise;
+}
+
+async function withStore(storeName, mode, callback) {
+  const db = await getDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, mode);
+    const store = tx.objectStore(storeName);
+    const result = callback(store);
+    tx.oncomplete = () => resolve(result && result.result ? result.result : result);
+    tx.onerror = () => reject(tx.error || (result && result.error));
+  });
+}
+
+export function list(storeName) {
+  return withStore(storeName, 'readonly', (store) => store.getAll());
+}
+
+export function get(storeName, key) {
+  return withStore(storeName, 'readonly', (store) => store.get(key));
+}
+
+export function put(storeName, value) {
+  return withStore(storeName, 'readwrite', (store) => store.put(value));
+}
+
+export function del(storeName, key) {
+  return withStore(storeName, 'readwrite', (store) => store.delete(key));
+}

--- a/public/js/sync/outbox.js
+++ b/public/js/sync/outbox.js
@@ -1,0 +1,29 @@
+import { put, list, del } from '../lib/db/indexeddb.js';
+import { db } from '../config/firebase.js';
+import { doc, setDoc, updateDoc } from '/vendor/firebase/9.6.0/firebase-firestore.js';
+
+export function enqueue(type, payload) {
+  return put('outbox', { type, payload });
+}
+
+export async function processOutbox() {
+  if (!navigator.onLine) return;
+  const items = await list('outbox');
+  for (const item of items) {
+    try {
+      if (item.type === 'visit:add') {
+        const { id, ...data } = item.payload;
+        await setDoc(doc(db, 'visits', id), data);
+      } else if (item.type === 'visit:update') {
+        const { id, changes } = item.payload;
+        const ref = id.includes('/') ? doc(db, ...id.split('/')) : doc(db, 'visits', id);
+        await updateDoc(ref, changes);
+      }
+      await del('outbox', item.id);
+    } catch (err) {
+      console.warn('[outbox] Failed to process item', item, err);
+    }
+  }
+}
+
+window.addEventListener('online', processOutbox);


### PR DESCRIPTION
## Summary
- add lightweight IndexedDB wrapper for visits and outbox stores
- queue and sync pending actions through an outbox
- load dashboard data from IndexedDB and process sync in background

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47174559c832ea9aa9c57192d067b