### PR TITLE
Mark visits as synced after processing outbox

### DIFF
--- a/public/js/sync/outbox.js
+++ b/public/js/sync/outbox.js
@@ -1,4 +1,4 @@
-import { put, list, del } from '../lib/db/indexeddb.js';
+import { get, put, list, del } from '../lib/db/indexeddb.js';
 import { db } from '../config/firebase.js';
 import { doc, setDoc, updateDoc } from '/vendor/firebase/9.6.0/firebase-firestore.js';
 
@@ -12,12 +12,24 @@ export async function processOutbox() {
   for (const item of items) {
     try {
       if (item.type === 'visit:add') {
-        const { id, ...data } = item.payload;
+        const { id, synced: _synced, ...data } = item.payload;
         await setDoc(doc(db, 'visits', id), data);
+        if (data.refId && data.type) {
+          const parts =
+            data.type === 'lead'
+              ? ['leads', data.refId, 'visits', id]
+              : ['clients', data.refId, 'visits', id];
+          await setDoc(doc(db, ...parts), { ...data, visitId: id });
+        }
+        const visit = await get('visits', id);
+        if (visit) await put('visits', { ...visit, synced: true });
       } else if (item.type === 'visit:update') {
         const { id, changes } = item.payload;
         const ref = id.includes('/') ? doc(db, ...id.split('/')) : doc(db, 'visits', id);
         await updateDoc(ref, changes);
+        const visitId = id.includes('/') ? id.split('/').pop() : id;
+        const visit = await get('visits', visitId);
+        if (visit) await put('visits', { ...visit, synced: true });
       }
       await del('outbox', item.id);
     } catch (err) {


### PR DESCRIPTION
## Summary
- mirror visit documents to lead or client subcollections when syncing
- track visit `synced` state locally and update after outbox processing

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden when fetching @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b473702174832e83087898258b6fe7