### PR TITLE
feat: sync visits from Firestore

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -22,12 +22,17 @@ import {
 import { getLeads, addLead, updateLead, syncLeadsFromFirestore } from '../stores/leadsStore.js';
 import { getClients, addClient, syncClientsFromFirestore } from '../stores/clientsStore.js';
 import { getProperties, addProperty } from '../stores/propertiesStore.js';
-import { listVisits, addVisit, updateVisit } from '../stores/visitsStore.js';
+import {
+  listVisits,
+  addVisit,
+  updateVisit,
+  syncVisitsFromFirestore,
+} from '../stores/visitsStore.js';
 import { processOutbox } from '../sync/outbox.js';
 import { addAgenda, getAgenda, updateAgenda, syncAgendaFromFirestore } from '../stores/agendaStore.js';
 import { getSales, addSale } from '../stores/salesStore.js';
 
-export function initAgronomoDashboard(userId, userRole) {
+export async function initAgronomoDashboard(userId, userRole) {
   if (window.__agroBooted) return;
   window.__agroBooted = true;
   const quickModal = document.getElementById('quickActionsModal');
@@ -1392,6 +1397,7 @@ export function initAgronomoDashboard(userId, userRole) {
             syncClientsFromFirestore(),
             syncLeadsFromFirestore(),
             syncAgendaFromFirestore(),
+            syncVisitsFromFirestore(),
             listVisits(), // atualiza cache de visitas
           ]);
           // Re-renderiza painéis impactados
@@ -1577,6 +1583,9 @@ try {
   bindHistoryEvents();
   renderAgendaHome(7);
   renderHomeKPIs();
+  if (navigator.onLine) {
+    await syncVisitsFromFirestore();
+  }
   renderHomeCharts();
   renderContactsList();
   window.addEventListener('hashchange', handleHashChange);

--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -1,5 +1,14 @@
 import { db, auth } from '../config/firebase.js';
-import { collection, doc, setDoc, updateDoc } from '/vendor/firebase/9.6.0/firebase-firestore.js';
+import {
+  collection,
+  doc,
+  setDoc,
+  updateDoc,
+  getDocs,
+  query,
+  where,
+  collectionGroup,
+} from '/vendor/firebase/9.6.0/firebase-firestore.js';
 import { list, get, put } from '../lib/db/indexeddb.js';
 import { enqueue } from '../sync/outbox.js';
 
@@ -22,6 +31,7 @@ export async function addVisit(visit) {
     authorId: userId,
     agronomistId: userId,
     synced: navigator.onLine ? true : false,
+    updatedAt: Date.now(),
     ...visit,
   };
   await put('visits', newVisit);
@@ -58,7 +68,13 @@ export async function addVisit(visit) {
 
 export async function updateVisit(id, changes) {
   const current = (await get('visits', id)) || { id };
-  const updated = { ...current, ...changes, id, synced: navigator.onLine ? true : false };
+  const updated = {
+    ...current,
+    ...changes,
+    id,
+    synced: navigator.onLine ? true : false,
+    updatedAt: Date.now(),
+  };
   await put('visits', updated);
 
   const send = async () => {
@@ -78,4 +94,99 @@ export async function updateVisit(id, changes) {
     await enqueue('visit:update', { id, changes });
   }
   return updated;
+}
+
+export async function syncVisitsFromFirestore() {
+  if (!navigator.onLine) return 0;
+  const userId =
+    (window.getCurrentUid && window.getCurrentUid()) || auth.currentUser?.uid || null;
+  if (!userId) return 0;
+
+  const allDocs = new Map();
+
+  const top = collection(db, 'visits');
+  const queries = [
+    query(top, where('authorId', '==', userId)),
+    query(top, where('agronomistId', '==', userId)),
+  ];
+  for (const q of queries) {
+    try {
+      const snap = await getDocs(q);
+      snap.forEach((d) => {
+        const norm = normalizeDoc(d);
+        if (norm) allDocs.set(norm.id, norm);
+      });
+    } catch (err) {
+      console.warn('[visitsStore] erro ao buscar visitas', err);
+    }
+  }
+
+  try {
+    const snap = await getDocs(
+      query(collectionGroup(db, 'visits'), where('authorId', '==', userId))
+    );
+    snap.forEach((d) => {
+      const norm = normalizeDoc(d);
+      if (norm && !allDocs.has(norm.id)) allDocs.set(norm.id, norm);
+    });
+  } catch (err) {
+    console.warn('[visitsStore] erro ao buscar subcoleções de visitas', err);
+  }
+
+  let upserted = 0;
+  for (const item of allDocs.values()) {
+    const local = await get('visits', item.id);
+    if (local && local.synced === false) {
+      if (!item.updatedAt) continue;
+      if (local.updatedAt && local.updatedAt > item.updatedAt) continue;
+    }
+    await put('visits', { ...local, ...item, synced: true });
+    upserted++;
+  }
+  return upserted;
+}
+
+function normalizeDoc(docSnap) {
+  const data = docSnap.data() || {};
+  const id = data.visitId || data.id || docSnap.id;
+  let at;
+  if (typeof data.at === 'string') at = data.at;
+  else if (data.at?.toDate) at = data.at.toDate().toISOString();
+  else if (data.date?.toDate) at = data.date.toDate().toISOString();
+  else if (data.checkInTime?.toDate) at = data.checkInTime.toDate().toISOString();
+  else if (data.createdAt?.toDate) at = data.createdAt.toDate().toISOString();
+
+  let updatedAt;
+  if (typeof data.updatedAt === 'number') updatedAt = data.updatedAt;
+  else if (data.updatedAt?.toMillis) updatedAt = data.updatedAt.toMillis();
+
+  let type = data.type || data.relatedType;
+  if (!type) {
+    if (data.clientId || data.refId) type = 'cliente';
+    else if (data.leadId) type = 'lead';
+  }
+
+  const refId =
+    data.refId || data.relatedId || data.clientId || data.leadId || undefined;
+
+  let lat = data.lat;
+  let lng = data.lng;
+  if (data.location && typeof data.location.latitude === 'number') {
+    lat = lat ?? data.location.latitude;
+    lng = lng ?? data.location.longitude;
+  }
+
+  return removeUndefinedFields({
+    id,
+    at,
+    authorId: data.authorId,
+    type,
+    refId,
+    notes: data.notes,
+    clientName: data.clientName,
+    leadName: data.leadName,
+    lat,
+    lng,
+    updatedAt,
+  });
 }


### PR DESCRIPTION
## Summary
- add Firestore pull sync for visits
- ensure local visits track updatedAt for merge
- trigger visit sync from dashboard boot and manual sync

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@capacitor%2fandroid)*

------
https://chatgpt.com/codex/tasks/task_e_68b475167270832e8dc2e02ed0ac4b61