### PR TITLE
feat: sync visits from firestore

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -1581,11 +1581,12 @@ try {
   bindAgendaHomeEvents();
   bindHomeShortcuts();
   bindHistoryEvents();
-  renderAgendaHome(7);
-  renderHomeKPIs();
   if (navigator.onLine) {
     await syncVisitsFromFirestore();
   }
+  renderAgendaHome(7);
+  renderHomeKPIs();
+  renderHistory();
   renderHomeCharts();
   renderContactsList();
   window.addEventListener('hashchange', handleHashChange);

--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -31,8 +31,8 @@ export async function addVisit(visit) {
     authorId: userId,
     agronomistId: userId,
     synced: navigator.onLine ? true : false,
-    updatedAt: Date.now(),
     ...visit,
+    updatedAt: visit?.updatedAt ?? Date.now(),
   };
   await put('visits', newVisit);
 
@@ -73,7 +73,7 @@ export async function updateVisit(id, changes) {
     ...changes,
     id,
     synced: navigator.onLine ? true : false,
-    updatedAt: Date.now(),
+    updatedAt: changes?.updatedAt ?? Date.now(),
   };
   await put('visits', updated);
 


### PR DESCRIPTION
## Summary
- ensure visits synced from Firestore before rendering dashboard
- preserve existing updatedAt when storing visits locally

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b479002218832ea07f1ad6d8244505