### PR TITLE
Use IndexedDB persistence on Capacitor

### DIFF
--- a/public/js/config/firebase.js
+++ b/public/js/config/firebase.js
@@ -19,7 +19,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
-// Inicializa Auth escolhendo a persistência adequada para cada ambiente
+// Inicializa Auth e define persistência (IndexedDB por padrão)
 const auth = getAuth(app);
 const isCapacitor =
   typeof window !== 'undefined' &&
@@ -30,8 +30,8 @@ const isCapacitor =
 (async () => {
   try {
     if (isCapacitor) {
-      await setPersistence(auth, browserLocalPersistence);
-      console.info('[auth] persistence=browserLocal (Capacitor)');
+      await setPersistence(auth, indexedDBLocalPersistence);
+      console.info('[auth] persistence=indexedDB (Capacitor)');
     } else {
       await setPersistence(auth, indexedDBLocalPersistence);
       console.info('[auth] persistence=indexedDB');


### PR DESCRIPTION
## Summary
- Ensure Firebase Auth uses IndexedDB persistence even on Capacitor builds, keeping the session across app restarts for offline usage

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@capacitor%2fandroid)*

------
https://chatgpt.com/codex/tasks/task_e_68b587579a64832eb5c865c357de870b