### PR TITLE
Handle offline fetch errors

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -225,7 +225,8 @@ self.addEventListener('fetch', (event) => {
       } catch (e) {
         const cached = await cache.match(req);
         if (cached) return cached;
-        throw e;
+        // Evita erro "Failed to fetch" quando offline
+        return new Response('', { status: 503, statusText: 'Service Unavailable' });
       }
     })
   );


### PR DESCRIPTION
## Summary
- Avoid unhandled fetch rejections in service worker by returning 503 offline response

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b589e19314832e8e4128c0673cc33b