### PR TITLE
Restrict visit listing to current agronomist

### DIFF
--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -16,8 +16,13 @@ function removeUndefinedFields(obj) {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined));
 }
 
-export function listVisits() {
-  return list('visits');
+export async function listVisits() {
+  const userId =
+    (window.getCurrentUid && window.getCurrentUid()) || auth.currentUser?.uid || null;
+  const all = await list('visits');
+  return userId
+    ? all.filter((v) => v.agronomistId === userId || v.authorId === userId)
+    : all;
 }
 
 export const getVisits = listVisits;

--- a/tests/unit/visitsStore.spec.ts
+++ b/tests/unit/visitsStore.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Provide global window object before module imports
+vi.stubGlobal('window', {} as any);
+
+vi.mock('../../public/js/lib/db/indexeddb.js', () => ({
+  list: vi.fn().mockResolvedValue([
+    { id: 'a', agronomistId: 'user1' },
+    { id: 'b', agronomistId: 'user2' },
+    { id: 'c', authorId: 'user1' },
+  ]),
+  get: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock('../../public/js/config/firebase.js', () => ({
+  auth: { currentUser: { uid: 'user1' } },
+  db: {},
+}));
+
+import { listVisits } from '../../public/js/stores/visitsStore.js';
+
+describe('listVisits', () => {
+  it('returns only visits belonging to current agronomist', async () => {
+    const visits = await listVisits();
+    expect(visits).toEqual([
+      { id: 'a', agronomistId: 'user1' },
+      { id: 'c', authorId: 'user1' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- only return visits where `agronomistId` or `authorId` match the logged-in user
- add unit test validating visit filtering

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee9eccac832e880da0f86ed388fb