### PR TITLE
Process outbox before manual sync

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -1447,6 +1447,7 @@ export async function initAgronomoDashboard(userId, userRole) {
         }
         try {
           showToast('Sincronizando…', 'info', 2000);
+          await processOutbox();
           await Promise.all([
             syncClientsFromFirestore(),
             syncLeadsFromFirestore(),


### PR DESCRIPTION
## Summary
- ensure offline outbox is processed before manual sync on agronomist dashboard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ca9ae184832e9b4b40a2fb5a28bb