### PR TITLE
Show registration notes on client profile and history

### DIFF
--- a/public/client-details.html
+++ b/public/client-details.html
@@ -33,6 +33,7 @@
         <div id="summaryName" class="font-semibold"></div>
         <div id="summaryProperty" class="text-sm text-gray-600"></div>
         <span id="summaryInterest" class="hidden text-xs font-semibold px-2 py-1 rounded"></span>
+        <div id="summaryNotes" class="text-sm text-gray-600"></div>
       </div>
       <button id="btnViewMap" class="btn-secondary mt-4">Ver no mapa</button>
     </section>

--- a/public/js/pages/client-details.js
+++ b/public/js/pages/client-details.js
@@ -25,6 +25,7 @@ export function initClientDetails(userId, userRole) {
   const summaryName = document.getElementById('summaryName');
   const summaryProperty = document.getElementById('summaryProperty');
   const summaryInterest = document.getElementById('summaryInterest');
+  const summaryNotes = document.getElementById('summaryNotes');
   const propertiesList = document.getElementById('propertiesList');
   const historyTimeline = document.getElementById('historyTimeline');
 
@@ -62,6 +63,8 @@ export function initClientDetails(userId, userRole) {
       if (clientNameHeader) clientNameHeader.textContent = data?.name || 'Cliente';
       if (summaryName) summaryName.textContent = data?.name || '';
       if (summaryInterest) summaryInterest.classList.add('hidden');
+      if (summaryNotes)
+        summaryNotes.textContent = data?.notes ? `Notas: ${data.notes}` : '';
     } catch (err) {
       console.error('Erro ao carregar cliente:', err);
       if (clientNameHeader) clientNameHeader.textContent = 'Erro ao carregar';
@@ -79,6 +82,8 @@ export function initClientDetails(userId, userRole) {
       summaryInterest.className = `text-xs font-semibold px-2 py-1 rounded ${interestClass(lead.interest)}`;
       summaryInterest.classList.remove('hidden');
     }
+    if (summaryNotes)
+      summaryNotes.textContent = lead.notes ? `Notas: ${lead.notes}` : '';
     document.getElementById('propertiesSection')?.classList.add('hidden');
   }
 

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -129,13 +129,13 @@ export async function initAgronomoDashboard(userId, userRole) {
       id: `lead-${l.id}`,
       type: 'add',
       at: l.createdAt,
-      text: `Lead cadastrado: ${l.name}`
+      text: `Lead cadastrado: ${l.name}${l.notes ? ' - ' + l.notes : ''}`
     }));
     const clients = getClients().map((c) => ({
       id: `client-${c.id}`,
       type: 'add',
       at: c.createdAt,
-      text: `Cliente cadastrado: ${c.name}`
+      text: `Cliente cadastrado: ${c.name}${c.notes ? ' - ' + c.notes : ''}`
     }));
     let events = [...visits, ...leads, ...clients].filter((e) => e.at);
     if (historyFilter === 'visits') events = events.filter((e) => e.type === 'visit');
@@ -832,7 +832,7 @@ export async function initAgronomoDashboard(userId, userRole) {
           highlightContactId = null;
         }
       } else {
-        created = addClient({ name });
+        created = addClient({ name, notes });
         addProperty({
           clientId: created.id,
           name: farm,
@@ -931,7 +931,7 @@ export async function initAgronomoDashboard(userId, userRole) {
         visit.sale = saleData;
         const lead = getLeads().find((l) => l.id === refId);
         if (lead) {
-          const client = addClient({ name: lead.name });
+          const client = addClient({ name: lead.name, notes: lead.notes });
           let lat = lead.lat;
           let lng = lead.lng;
           if (lat == null || lng == null || isNaN(lat) || isNaN(lng)) {

--- a/public/js/pages/lead-details.js
+++ b/public/js/pages/lead-details.js
@@ -36,6 +36,7 @@ export function initLeadDetails(userId, userRole) {
   const leadEmail = document.getElementById('leadEmail');
   const leadProperty = document.getElementById('leadProperty');
   const leadOrigin = document.getElementById('leadOrigin');
+  const leadNotes = document.getElementById('leadNotes');
   const leadStage = document.getElementById('leadStage');
   const visitsTimeline = document.getElementById('visitsTimeline');
   const btnAddVisit = document.getElementById('btnAddVisit');
@@ -90,6 +91,7 @@ export function initLeadDetails(userId, userRole) {
     if (leadProperty)
       leadProperty.textContent = lead.propertyName || lead.property || '';
     if (leadOrigin) leadOrigin.textContent = lead.origin || lead.source || '';
+    if (leadNotes) leadNotes.textContent = lead.notes || '';
     if (leadStage && lead.stage) {
       const color = STAGE_COLORS[lead.stage] || 'bg-gray-100 text-gray-800';
       leadStage.textContent = lead.stage;
@@ -137,6 +139,7 @@ export function initLeadDetails(userId, userRole) {
     if (leadProperty)
       leadProperty.textContent = data.propertyName || data.property || '';
     if (leadOrigin) leadOrigin.textContent = data.origin || data.source || '';
+    if (leadNotes) leadNotes.textContent = data.notes || '';
     if (leadStage && data.stage) {
       const color = STAGE_COLORS[data.stage] || 'bg-gray-100 text-gray-800';
       leadStage.textContent = data.stage;
@@ -453,6 +456,7 @@ export function initLeadDetails(userId, userRole) {
         email: data.email || '',
         origin: data.origin || data.source || '',
         propertyName: data.propertyName || data.property || '',
+        notes: data.notes || '',
         status: 'ativo',
         isFavorite: false,
         tier: 'standard',

--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -64,6 +64,10 @@
           <span class="block text-xs text-gray-500">Origem</span>
           <div id="leadOrigin" class="text-sm text-gray-600"></div>
         </div>
+        <div>
+          <span class="block text-xs text-gray-500">Notas</span>
+          <div id="leadNotes" class="text-sm text-gray-600"></div>
+        </div>
         <div class="flex items-center">
           <span id="leadStage" class="hidden text-xs font-semibold px-2 py-1 rounded"></span>
         </div>


### PR DESCRIPTION
## Summary
- Display notes for leads and clients in their detail pages
- Include registration notes in dashboard history events
- Preserve lead notes when converting to clients

## Testing
- `npm test` *(fails: vitest not found, installation forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d504b6e4832eba235f7b3b573f58