### PR TITLE
fix: auto-set visit times to Brasília timezone

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -290,7 +290,7 @@
         <button type="button" id="btnVisitQuickCreate" class="btn-secondary">Cadastrar novo (rápido)</button>
         <div class="field">
           <label for="visitAt">Data/Hora</label>
-          <input id="visitAt" type="datetime-local" class="input" required />
+          <input id="visitAt" type="datetime-local" class="input" required readonly />
         </div>
         <div class="field">
           <label for="visitNotes">Descrição*</label>
@@ -376,7 +376,7 @@
       <form id="leadVisitForm" class="grid gap-4">
         <div class="field">
           <label for="leadVisitDate">Data/Hora</label>
-          <input id="leadVisitDate" type="datetime-local" class="input" required />
+          <input id="leadVisitDate" type="datetime-local" class="input" required readonly />
         </div>
         <div class="field">
           <label for="leadVisitSummary">Resumo*</label>

--- a/public/js/lib/date-utils.js
+++ b/public/js/lib/date-utils.js
@@ -29,3 +29,42 @@ export function endOfLocalDay(date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
 }
 
+export function nowBrasiliaISO() {
+  const tz = 'America/Sao_Paulo';
+  const now = new Date();
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(now);
+  const map = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  const offsetMatch = now
+    .toLocaleString('en-US', { timeZone: tz, timeZoneName: 'short' })
+    .match(/GMT([+-]\d{1,2})/);
+  const offsetHours = offsetMatch ? parseInt(offsetMatch[1], 10) : 0;
+  const sign = offsetHours >= 0 ? '+' : '-';
+  const offset = `${sign}${String(Math.abs(offsetHours)).padStart(2, '0')}:00`;
+  return `${map.year}-${map.month}-${map.day}T${map.hour}:${map.minute}:${map.second}${offset}`;
+}
+
+export function nowBrasiliaLocal() {
+  const tz = 'America/Sao_Paulo';
+  const now = new Date();
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(now);
+  const map = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  return `${map.year}-${map.month}-${map.day}T${map.hour}:${map.minute}`;
+}
+

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -31,6 +31,7 @@ import {
 import { processOutbox } from '../sync/outbox.js';
 import { addAgenda, getAgenda, updateAgenda, syncAgendaFromFirestore } from '../stores/agendaStore.js';
 import { getSales, addSale } from '../stores/salesStore.js';
+import { nowBrasiliaISO, nowBrasiliaLocal } from '../lib/date-utils.js';
 
 export async function initAgronomoDashboard(userId, userRole) {
   if (window.__agroBooted) return;
@@ -347,7 +348,7 @@ export async function initAgronomoDashboard(userId, userRole) {
     populateVisitSelect('cliente');
     document.querySelector("input[name='visitTarget'][value='cliente']").checked = true;
     visitForm.reset();
-    document.getElementById('visitAt').value = new Date().toISOString().slice(0, 16);
+    document.getElementById('visitAt').value = nowBrasiliaLocal();
     leadExtras.classList.add('hidden');
     toggleModal(visitModal, true);
   }
@@ -366,7 +367,7 @@ export async function initAgronomoDashboard(userId, userRole) {
     currentLeadId = leadId;
     leadVisitForm?.reset();
     if (leadVisitDate)
-      leadVisitDate.value = new Date().toISOString().slice(0, 16);
+      leadVisitDate.value = nowBrasiliaLocal();
     // Garante estado inicial dos campos de tarefa
     if (leadVisitTaskFields) leadVisitTaskFields.classList.add('hidden');
     toggleModal(leadVisitModal, true);
@@ -408,7 +409,7 @@ export async function initAgronomoDashboard(userId, userRole) {
       const saved = await addVisit({
         type: 'lead',
         refId: currentLeadId,
-        at: leadVisitDate?.value || new Date().toISOString(),
+        at: nowBrasiliaISO(),
         summary,
         notes: leadVisitNotes?.value.trim() || summary,
         leadName: getLeads().find((l) => l.id === currentLeadId)?.name,
@@ -888,13 +889,8 @@ export async function initAgronomoDashboard(userId, userRole) {
     const type = document.querySelector("input[name='visitTarget']:checked").value;
     const refId = visitSelect.value;
     if (!refId) return;
-    const atEl = document.getElementById('visitAt');
     const notesEl = document.getElementById('visitNotes');
     let valid = true;
-    if (!atEl.value) {
-      setFieldError(atEl, 'Campo obrigatório');
-      valid = false;
-    }
     if (!notesEl.value.trim()) {
       setFieldError(notesEl, 'Campo obrigatório');
       valid = false;
@@ -902,7 +898,7 @@ export async function initAgronomoDashboard(userId, userRole) {
     const visit = {
       type,
       refId,
-      at: atEl.value,
+      at: nowBrasiliaISO(),
       notes: notesEl.value.trim(),
     };
     if (type === 'lead') {

--- a/public/js/pages/lead-details.js
+++ b/public/js/pages/lead-details.js
@@ -5,6 +5,7 @@ import { toggleModal } from './agro-bottom-nav.js';
 import { getLeads } from '../stores/leadsStore.js';
 import { getVisits, addVisit, updateVisit } from '../stores/visitsStore.js';
 import { getCurrentPositionSafe } from '../utils/geo.js';
+import { nowBrasiliaLocal, nowBrasiliaISO } from '../lib/date-utils.js';
 import {
   doc,
   getDoc,
@@ -414,7 +415,7 @@ export function initLeadDetails(userId, userRole) {
 
 
   btnAddVisit?.addEventListener('click', () => {
-    const nowIso = new Date().toISOString().slice(0, 16);
+    const nowIso = nowBrasiliaLocal();
     if (leadVisitDate) {
       leadVisitDate.min = nowIso;
       leadVisitDate.value = nowIso;
@@ -508,13 +509,12 @@ export function initLeadDetails(userId, userRole) {
       showToast('Corrija os erros antes de salvar.', 'error');
       return;
     }
-    const value = leadVisitDate?.value;
     try {
       const pos = await getCurrentPositionSafe();
       const saved = await addVisit({
         type: 'lead',
         refId: leadId,
-        at: value || new Date().toISOString(),
+        at: nowBrasiliaISO(),
         summary: leadVisitSummary?.value.trim(),
         notes: leadVisitNotes?.value.trim() || leadVisitSummary?.value.trim(),
         outcome: leadVisitOutcome?.value || 'realizada',

--- a/public/js/stores/clientsStore.js
+++ b/public/js/stores/clientsStore.js
@@ -1,4 +1,5 @@
 import { db, auth } from '../config/firebase.js';
+import { nowBrasiliaISO } from '../lib/date-utils.js';
 import {
   doc,
   setDoc,
@@ -27,7 +28,7 @@ export function getClients() {
 export function addClient(client) {
   const userId = (window.getCurrentUid && window.getCurrentUid()) || auth.currentUser?.uid || null;
   const all = readLocal();
-  const now = new Date().toISOString();
+  const now = nowBrasiliaISO();
   const newClient = {
     id: `local-${Date.now().toString(36)}`,
     createdAt: now,

--- a/public/js/stores/leadsStore.js
+++ b/public/js/stores/leadsStore.js
@@ -1,4 +1,5 @@
 ﻿import { db, auth } from '../config/firebase.js';
+import { nowBrasiliaISO } from '../lib/date-utils.js';
 import {
   doc,
   setDoc,
@@ -27,7 +28,7 @@ export function getLeads() {
 export function addLead(lead) {
   const userId = (window.getCurrentUid && window.getCurrentUid()) || auth.currentUser?.uid || null;
   const all = readLocal();
-  const now = new Date().toISOString();
+  const now = nowBrasiliaISO();
   const newLead = {
     id: `local-${Date.now().toString(36)}`,
     createdAt: now,
@@ -62,7 +63,7 @@ export function updateLead(id, changes) {
   const all = readLocal();
   const idx = all.findIndex((l) => l.id === id);
   if (idx >= 0) {
-    all[idx] = { ...all[idx], ...changes, updatedAt: new Date().toISOString(), synced: navigator.onLine ? true : false };
+    all[idx] = { ...all[idx], ...changes, updatedAt: nowBrasiliaISO(), synced: navigator.onLine ? true : false };
     saveLocal(all);
   }
   if (navigator.onLine) {

--- a/public/js/stores/visitsStore.js
+++ b/public/js/stores/visitsStore.js
@@ -1,4 +1,5 @@
 import { db, auth } from '../config/firebase.js';
+import { nowBrasiliaISO } from '../lib/date-utils.js';
 import {
   collection,
   doc,
@@ -32,7 +33,7 @@ export async function addVisit(visit) {
   const id = doc(collection(db, 'visits')).id;
   const newVisit = {
     id,
-    at: new Date().toISOString(),
+    at: nowBrasiliaISO(),
     authorId: userId,
     agronomistId: userId,
     synced: navigator.onLine ? true : false,

--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -92,7 +92,7 @@
       <form id="leadAddVisitForm" class="grid gap-4">
         <div class="field">
           <label for="leadVisitDate">Data/Hora*</label>
-          <input id="leadVisitDate" type="datetime-local" class="input" required placeholder="Selecione a data e hora" />
+          <input id="leadVisitDate" type="datetime-local" class="input" required readonly placeholder="Selecione a data e hora" />
           <small class="text-xs text-gray-500">Informe uma data futura para a visita.</small>
           <p id="leadVisitDateError" class="error hidden"></p>
         </div>


### PR DESCRIPTION
## Summary
- lock visit date inputs and auto-fill using Brasília timezone
- capture lead/client creation and visit timestamps in Brasília timezone

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ff5026d0832e9783950327fdc5bd