### PR TITLE
Add network status indicator to agronomo dashboard

### DIFF
--- a/agronomooffline/index.html
+++ b/agronomooffline/index.html
@@ -25,6 +25,7 @@
   <header class="bg-white shadow-md sticky top-0 z-20">
     <div class="px-4 py-3 flex justify-between items-center">
       <h1 class="text-lg font-bold" style="color: var(--brand-green);">Painel do Agrônomo</h1>
+      <div id="networkStatus" class="text-sm font-medium"></div>
       <div class="flex items-center space-x-2">
         <input type="file" id="importOfflineInput" class="hidden" />
         <button id="importOfflineBtn" class="px-3 py-1.5 bg-gray-600 text-white font-semibold rounded-lg hover:bg-gray-700 text-sm">Importar</button>

--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -37,6 +37,20 @@ let currentModal;
 let lastFocusedElement;
 let focusableElements = [];
 
+const networkStatusEl = document.getElementById('networkStatus');
+
+function updateNetworkStatus() {
+  if (!networkStatusEl) return;
+  const online = navigator.onLine;
+  networkStatusEl.textContent = online ? 'Online' : 'Offline';
+  networkStatusEl.classList.toggle('online', online);
+  networkStatusEl.classList.toggle('offline', !online);
+}
+
+window.addEventListener('online', updateNetworkStatus);
+window.addEventListener('offline', updateNetworkStatus);
+updateNetworkStatus();
+
 function handleModalKeydown(e) {
   if (!currentModal) return;
   if (e.key === 'Escape') {

--- a/public/style.css
+++ b/public/style.css
@@ -1149,3 +1149,19 @@ body.has-modal{overflow:hidden;}
 
 /* Reserve space so content never hides under the fixed bottom bar */
 #agroMain{padding-bottom:calc(var(--bottom-bar-h) + env(safe-area-inset-bottom, 0px));}
+
+/* Network status indicator */
+#networkStatus {
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+}
+
+#networkStatus.online {
+    background-color: #d1fae5;
+    color: #065f46;
+}
+
+#networkStatus.offline {
+    background-color: #fee2e2;
+    color: #991b1b;
+}


### PR DESCRIPTION
## Summary
- show network status in agronomo offline header
- update dashboard script to handle online/offline events
- style network status indicator for online/offline states

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b739bebf80832e975ba08c061c3bbd