### PR TITLE
fix: remove extra closing brace from agronomo dashboard script

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -1247,4 +1247,4 @@ try {
   });
   processOutbox();
   handleHashChange();
-}
+


### PR DESCRIPTION
## Summary
- fix syntax error in dashboard-agronomo.js by removing stray closing brace

## Testing
- `node --check public/js/pages/dashboard-agronomo.js`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8189939b8832eb7c98fb4020d7b46