### PR TITLE
fix: guard leads summary elements

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -720,9 +720,12 @@ export async function initAgronomoDashboard(userId, userRole) {
     leads.forEach((l) => {
       if (counts[l.interest] >= 0) counts[l.interest]++;
     });
-    document.getElementById('leadCountInteressado').textContent = counts['Interessado'];
-    document.getElementById('leadCountNaDuvida').textContent = counts['Na dúvida'];
-    document.getElementById('leadCountSemInteresse').textContent = counts['Sem interesse'];
+    const elInteressado = document.getElementById('leadCountInteressado');
+    if (elInteressado) elInteressado.textContent = String(counts['Interessado']);
+    const elNaDuvida = document.getElementById('leadCountNaDuvida');
+    if (elNaDuvida) elNaDuvida.textContent = String(counts['Na dúvida']);
+    const elSemInteresse = document.getElementById('leadCountSemInteresse');
+    if (elSemInteresse) elSemInteresse.textContent = String(counts['Sem interesse']);
   }
 
   async function renderLeadsList() {


### PR DESCRIPTION
## Summary
- avoid accessing missing DOM nodes when rendering leads summary

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `TZ=America/Sao_Paulo npx vitest run --reporter=dot` *(fails: 403 Forbidden fetching vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_68b979905eac832e8b3e2a2c95dced04