### PR TITLE
fix: initialize home view once

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -444,8 +444,10 @@ export async function initAgronomoDashboard(userId, userRole) {
   let renderHomeKPIs = () => {};
   let renderHomeCharts = () => {};
   let renderAgendaHome = () => {};
+  let homeViewInitialized = false;
+
   function ensureHomeViewInit() {
-    if (!renderHomeKPIs) {
+    if (!homeViewInitialized) {
       const fns = initHomeView({
         openVisitModal,
         openQuickCreateModal,
@@ -453,6 +455,7 @@ export async function initAgronomoDashboard(userId, userRole) {
         renderHistory,
       });
       ({ renderHomeKPIs, renderHomeCharts, renderAgendaHome } = fns);
+      homeViewInitialized = true;
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure Agronomo dashboard home view initializes lazily only once

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@capacitor%2fandroid)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d52f2e4832e8afebbf6d25bcd92