### PR TITLE
Fix agronomist dashboard alignment

### DIFF
--- a/agronomooffline/index.html
+++ b/agronomooffline/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no" />
   <meta name="theme-color" content="#166534" />
   <base href="../public/" />
   <link rel="icon" type="image/png" href="favicon.png" />
@@ -23,7 +23,7 @@
   <div id="dashboard-agronomo-marker" hidden></div>
 
   <header class="bg-white shadow-md sticky top-0 z-20">
-    <div class="px-4 py-3 flex justify-between items-center">
+    <div class="page-container px-4 py-3 flex justify-between items-center">
       <h1 class="text-lg font-bold" style="color: var(--brand-green);">Painel do Agrônomo</h1>
       <div id="networkStatus" class="text-sm font-medium"></div>
       <div class="flex items-center space-x-2">

--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no" />
   <meta name="theme-color" content="#166534" />
   <link rel="icon" type="image/png" href="/favicon.png" />
   <link rel="manifest" href="/manifest.json" />
@@ -22,7 +22,7 @@
   <div id="dashboard-agronomo-marker" hidden></div>
 
   <header class="bg-white shadow-md sticky top-0 z-20">
-    <div class="px-4 py-3 flex justify-between items-center">
+    <div class="page-container px-4 py-3 flex justify-between items-center">
       <h1 class="text-lg font-bold" style="color: var(--brand-green);">Painel do Agrônomo</h1>
       <div class="flex items-center space-x-2">
         <button id="exportOfflineBtn" class="px-3 py-1.5 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 text-sm">Exportar</button>


### PR DESCRIPTION
## Summary
- prevent inadvertent zoom by making dashboards non-scalable
- center header content with `page-container`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b982d43da0832eaa2436767cfe9d78