### PR TITLE
Refatora layout da home e remove seções antigas

### DIFF
--- a/public/views/home.html
+++ b/public/views/home.html
@@ -1,126 +1,39 @@
     <section id="view-home">
-      <h2 class="p-4 text-xl font-semibold tracking-tight text-gray-800">Home</h2>
-      <div id="kpiGrid" class="page-container grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <div class="kpi-card bg-white rounded-2xl shadow-sm border border-gray-100 opacity-0 translate-y-4 stagger-item">
-          <div class="kpi-icon text-emerald-700"><i class="fas fa-sack-dollar" aria-hidden="true"></i></div>
-          <div class="kpi-text">
-            <div class="kpi-title">Vendas (t)</div>
-            <div id="kpiSales" class="kpi-value"></div>
-          </div>
+      <header class="page-container py-4">
+        <h2 id="homeGreeting" class="text-xl font-semibold tracking-tight text-gray-800">Olá</h2>
+        <div class="flex items-center gap-2 text-sm text-gray-500">
+          <span id="homeStatusDot" class="w-2 h-2 rounded-full bg-red-500"></span>
+          <span id="homeStatusText">Offline</span>
         </div>
-        <div class="kpi-card bg-white rounded-2xl shadow-sm border border-gray-100 opacity-0 translate-y-4 stagger-item">
-          <div class="kpi-icon text-emerald-700"><i class="fas fa-user-check" aria-hidden="true"></i></div>
-          <div class="kpi-text">
-            <div class="kpi-title">Visitas</div>
-            <div id="kpiVisits" class="kpi-value"></div>
-          </div>
-        </div>
-        <div class="kpi-card bg-white rounded-2xl shadow-sm border border-gray-100 opacity-0 translate-y-4 stagger-item">
-          <div class="kpi-icon text-emerald-700"><i class="fas fa-user-plus" aria-hidden="true"></i></div>
-          <div class="kpi-text">
-            <div class="kpi-title">Novos Leads</div>
-            <div id="kpiLeads" class="kpi-value"></div>
-          </div>
-        </div>
-        <div class="kpi-card bg-white rounded-2xl shadow-sm border border-gray-100 opacity-0 translate-y-4 stagger-item">
-          <div id="kpiAgenda" class="kpi-value text-3xl font-bold text-gray-800 rounded group-hover:ring-1 group-hover:ring-green-600/20"></div>
-          <div class="text-sm text-gray-500">Pendências (7d)</div>
-        </div>
-      </div>
+      </header>
 
-      <div id="chartsSection" class="page-container grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <div id="chartSales" class="card-soft opacity-0 translate-y-4 stagger-item"></div>
-        <div id="chartVisits" class="card-soft opacity-0 translate-y-4 stagger-item"></div>
-        <div id="chartLeadsFunnel" class="card-soft flex gap-2 opacity-0 translate-y-4 stagger-item"></div>
-      </div>
-      <div id="homeShortcuts" class="page-container grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
-        <button
-          id="quickHomeAddContato"
-          aria-label="Adicionar contato"
-          class="w-full flex flex-col items-center justify-center gap-1 p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transform transition duration-200 ease-in-out hover:scale-105 opacity-0 translate-y-4 stagger-item"
-        >
-          <svg class="w-6 h-6 text-emerald-700" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M16 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2" />
-            <circle cx="12" cy="7" r="4" />
-            <line x1="20" y1="8" x2="20" y2="14" />
-            <line x1="17" y1="11" x2="23" y2="11" />
-          </svg>
-          <span class="text-sm text-gray-500">Adicionar contato</span>
+      <nav id="homeShortcutBar" class="page-container flex gap-2 overflow-x-auto py-2 mb-6">
+        <button id="shortcutAddVisit" class="flex items-center gap-2 px-3 py-2 bg-white rounded-lg shadow text-sm">
+          <i class="fas fa-calendar-plus text-emerald-700" aria-hidden="true"></i>
+          <span>Adicionar visita</span>
         </button>
-        <button
-          id="quickHomeAddVisit"
-          aria-label="Registrar Visita"
-          class="w-full flex flex-col items-center justify-center gap-1 p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transform transition duration-200 ease-in-out hover:scale-105 opacity-0 translate-y-4 stagger-item"
-        >
-          <svg class="w-6 h-6 text-emerald-700" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 21s-7-7.58-7-12.5a7 7 0 1114 0C19 13.42 12 21 12 21z" />
-            <circle cx="12" cy="8.5" r="3.5" />
-          </svg>
-          <span class="text-sm text-gray-500">Registrar Visita</span>
+        <button id="shortcutNewLead" class="flex items-center gap-2 px-3 py-2 bg-white rounded-lg shadow text-sm">
+          <i class="fas fa-user-plus text-emerald-700" aria-hidden="true"></i>
+          <span>Novo lead</span>
         </button>
-        <button
-          id="quickHomeOpenMap"
-          aria-label="Abrir Mapa"
-          class="w-full flex flex-col items-center justify-center gap-1 p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transform transition duration-200 ease-in-out hover:scale-105 opacity-0 translate-y-4 stagger-item"
-        >
-          <svg class="w-6 h-6 text-emerald-700" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 3l6 2 6-2v16l-6 2-6-2-6 2V5l6-2v16" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 5v16" />
-          </svg>
-          <span class="text-sm text-gray-500">Abrir Mapa</span>
+        <button id="shortcutOpenMap" class="flex items-center gap-2 px-3 py-2 bg-white rounded-lg shadow text-sm">
+          <i class="fas fa-map-marked-alt text-emerald-700" aria-hidden="true"></i>
+          <span>Abrir mapa</span>
         </button>
-        <button
-          id="quickHomeOpenContacts"
-          aria-label="Abrir Contatos"
-          class="w-full flex flex-col items-center justify-center gap-1 p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transform transition duration-200 ease-in-out hover:scale-105 opacity-0 translate-y-4 stagger-item"
-        >
-          <svg class="w-6 h-6 text-emerald-700" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M18 21v-2a4 4 0 00-4-4h-2" />
-            <circle cx="12" cy="7" r="4" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 21v-2a4 4 0 00-3-3.87" />
-            <circle cx="6" cy="10" r="3" />
-          </svg>
-          <span class="text-sm text-gray-500">Abrir Contatos</span>
+        <button id="shortcutSync" class="flex items-center gap-2 px-3 py-2 bg-white rounded-lg shadow text-sm">
+          <i class="fas fa-sync-alt text-emerald-700" aria-hidden="true"></i>
+          <span>Sincronizar</span>
         </button>
-        <button
-          id="quickHomeGotoAgenda"
-          aria-label="Agenda (7d)"
-          class="w-full flex flex-col items-center justify-center gap-1 p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transform transition duration-200 ease-in-out hover:scale-105 opacity-0 translate-y-4 stagger-item"
-        >
-          <svg class="w-6 h-6 text-emerald-700" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3 7h18M7 3v4m10-4v4M5 21h14a2 2 0 002-2V7H3v12a2 2 0 002 2z" />
-          </svg>
-          <span class="text-sm text-gray-500">Agenda (7d)</span>
-        </button>
-        <button
-          id="quickHomeSyncNow"
-          aria-label="Sincronizar agora"
-          class="w-full flex flex-col items-center justify-center gap-1 p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transform transition duration-200 ease-in-out hover:scale-105 opacity-0 translate-y-4 stagger-item"
-        >
-          <svg class="w-6 h-6 text-emerald-700" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v6h6M20 20v-6h-6M20 8a8 8 0 10-8 8" />
-          </svg>
-          <span class="text-sm text-gray-500">Sincronizar</span>
-        </button>
-      </div>
-      <div id="agendaHome" class="page-container card-soft opacity-0 translate-y-4 stagger-item">
-        <div class="flex items-center justify-between mb-2">
-          <h3 class="text-xl font-semibold tracking-tight text-gray-800">Próximos compromissos</h3>
-          <select id="agendaPeriod" class="input w-32">
-            <option value="7">7 dias</option>
-            <option value="30">30 dias</option>
-            <option value="90">90 dias</option>
-          </select>
-        </div>
-          <ul id="agendaList" class="space-y-3" aria-live="polite"></ul>
-          <div
-            id="agendaEmpty"
-            class="hidden text-center bg-white border border-dashed rounded-2xl p-6 text-gray-500"
-            aria-live="polite"
-          >
-            <i class="fas fa-calendar text-3xl mb-2 text-gray-400" aria-hidden="true"></i>
-            <p class="mb-2">Nenhum compromisso futuro.</p>
-            <button id="btnAgendaAddVisit" class="btn-primary">Registrar visita</button>
-          </div>
-        </div>
+      </nav>
+
+      <section id="todaySection" class="page-container mb-6">
+        <h3 class="text-lg font-semibold tracking-tight text-gray-800">Hoje</h3>
+        <ul id="todayAppointments" class="space-y-2"></ul>
+        <ul id="todayCriticalLeads" class="space-y-2 mt-4"></ul>
+      </section>
+
+      <section id="recentActivities" class="page-container mb-6">
+        <h3 class="text-lg font-semibold tracking-tight text-gray-800">Atividades recentes</h3>
+        <ul id="recentActivitiesList" class="space-y-2"></ul>
+      </section>
     </section>


### PR DESCRIPTION
## Summary
- Simplifica `home.html` com cabeçalho e status online/offline
- Adiciona seção "Hoje" para compromissos e leads críticos
- Exibe "Atividades recentes" e barra compacta de atalhos

## Testing
- `npm test` *(erro: vitest: not found)*
- `npm install` *(falha ao baixar @capacitor/android: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b98aa9e684832e99a79ffe7b9f4a5b