### PR TITLE
Refactor home view initialization

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -444,21 +444,7 @@ export async function initAgronomoDashboard(userId, userRole) {
   let renderTodayAgenda = () => {};
   let renderRecentActivity = () => {};
   let bindQuickActions = () => {};
-  let homeViewInitialized = false;
-
-  function ensureHomeViewInit() {
-    if (!homeViewInitialized) {
-      const fns = initHomeSummaryView({
-        openVisitModal,
-        openQuickCreateModal,
-        replotMap,
-        renderHistory,
-      });
-      ({ renderTodayAgenda, renderRecentActivity, bindQuickActions } = fns);
-      bindQuickActions();
-      homeViewInitialized = true;
-    }
-  }
+  let quickActionsBound = false;
 
   function openLeadVisitModal(leadId) {
     currentLeadId = leadId;
@@ -1229,7 +1215,17 @@ export async function initAgronomoDashboard(userId, userRole) {
     }
     await loadView(hash);
     if (hash === '#home') {
-      ensureHomeViewInit();
+      ({ renderTodayAgenda, renderRecentActivity, bindQuickActions } =
+        initHomeSummaryView({
+          openVisitModal,
+          openQuickCreateModal,
+          replotMap,
+          renderHistory,
+        }));
+      if (!quickActionsBound) {
+        bindQuickActions();
+        quickActionsBound = true;
+      }
       renderTodayAgenda();
       renderRecentActivity();
     }


### PR DESCRIPTION
## Summary
- remove old home view init helper and unnecessary variables
- initialize home summary view and render routines on hash change

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b98ede2828832eb1dae98cc5d6d4bb