### PR TITLE
Add Home button to agronomist dashboard bottom bar

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -34,6 +34,10 @@
   <main id="agroMain" class="pb-16"></main>
 
   <nav id="bottomBar" class="bottom-bar">
+    <button data-nav="#home" aria-label="Home">
+      <i class="fas fa-home" aria-hidden="true"></i>
+      <span class="sr-only">Home</span>
+    </button>
     <button data-nav="#contatos" aria-label="Contatos">
       <i class="fas fa-users" aria-hidden="true"></i>
       <span class="sr-only">Contatos</span>


### PR DESCRIPTION
## Summary
- add Home navigation button with fa-home icon and sr-only text

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c3d52354832eb0f838219e6b9f8f