### PR TITLE
feat: set default bottom navigation to home

### DIFF
--- a/public/js/pages/agro-bottom-nav.js
+++ b/public/js/pages/agro-bottom-nav.js
@@ -2,7 +2,7 @@ export function initBottomNav() {
   const buttons = document.querySelectorAll('#bottomBar button');
 
   function setActive(hash) {
-    const target = hash || '#contatos';
+    const target = hash || '#home';
     buttons.forEach((b) => {
       if (b.dataset.nav === target) {
         b.classList.add('active');
@@ -22,9 +22,9 @@ export function initBottomNav() {
     }
   });
 
-  window.addEventListener('hashchange', () => setActive(location.hash));
-  if (!location.hash) location.hash = '#contatos';
-  setActive(location.hash);
+  window.addEventListener('hashchange', () => setActive(location.hash || '#home'));
+  if (!location.hash) location.hash = '#home';
+  setActive(location.hash || '#home');
 }
 
 export function bindPlus(handler) {


### PR DESCRIPTION
## Summary
- default bottom nav active tab to `#home`
- update hash change handling to set `#home` when none

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c5abc4a4832e940eaaf389355e74