### PR TITLE
Add home button next to clients in bottom bar

### DIFF
--- a/agronomooffline/index.html
+++ b/agronomooffline/index.html
@@ -120,6 +120,10 @@
   </main>
 
   <nav id="bottomBar" class="bottom-bar">
+    <button data-nav="#clientes" aria-label="Clientes">
+      <i class="fas fa-user" aria-hidden="true"></i>
+      <span class="sr-only">Clientes</span>
+    </button>
     <button data-nav="#home" aria-label="Home">
       <i class="fas fa-home" aria-hidden="true"></i>
       <span class="sr-only">Home</span>

--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -34,6 +34,10 @@
   <main id="agroMain" class="pb-16"></main>
 
   <nav id="bottomBar" class="bottom-bar">
+    <button data-nav="#clientes" aria-label="Clientes">
+      <i class="fas fa-user" aria-hidden="true"></i>
+      <span class="sr-only">Clientes</span>
+    </button>
     <button data-nav="#home" aria-label="Home">
       <i class="fas fa-home" aria-hidden="true"></i>
       <span class="sr-only">Home</span>


### PR DESCRIPTION
## Summary
- Insert home navigation button after clients in bottom bar for agronomist dashboard and offline page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ccab9694832ea026972c85a7dfc3