### PR TITLE
Add home stats section

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -30,7 +30,7 @@ import {
 } from '../stores/visitsStore.js';
 import { processOutbox } from '../sync/outbox.js';
 import { addAgenda, getAgenda, updateAgenda, syncAgendaFromFirestore } from '../stores/agendaStore.js';
-import { addSale } from '../stores/salesStore.js';
+import { addSale, getSales } from '../stores/salesStore.js';
 import { nowBrasiliaISO, nowBrasiliaLocal } from '../lib/date-utils.js';
 
 let currentModal;
@@ -176,6 +176,26 @@ export async function initAgronomoDashboard(userId, userRole) {
         el.classList.remove('opacity-0', 'translate-y-4');
       }, index * 100);
     });
+  }
+
+  async function renderHomeStats() {
+    const container = document.getElementById('homeStats');
+    if (!container) return;
+    const clientCount = getClients().length;
+    const leadCount = getLeads().length;
+    const visitCount = (await listVisits()).length;
+    const saleCount = typeof getSales === 'function' ? getSales().length : 0;
+    const stats = [
+      { label: 'Clientes', value: clientCount },
+      { label: 'Leads', value: leadCount },
+      { label: 'Visitas', value: visitCount },
+      { label: 'Vendas', value: saleCount },
+    ];
+    container.innerHTML = stats
+      .map(
+        (s) => `\n      <div class="card-soft home-stat-card">\n        <span class="stat-value">${s.value}</span>\n        <span>${s.label}</span>\n      </div>`
+      )
+      .join('');
   }
 
   function clearErrors(form) {
@@ -1199,6 +1219,9 @@ export async function initAgronomoDashboard(userId, userRole) {
       location.hash = hash;
     }
     await loadView(hash);
+    if (hash === '#home') {
+      await renderHomeStats();
+    }
     if (hash === '#mapa') {
       bindMapEvents();
       initAgroMap();

--- a/public/style.css
+++ b/public/style.css
@@ -86,6 +86,20 @@ html,body{margin:0;overflow-x:hidden;-webkit-text-size-adjust:100%;text-size-adj
 @media (max-width:1023px){.stats-grid{grid-template-columns:repeat(2,1fr);}}
 @media (max-width:599px){.stats-grid{grid-template-columns:1fr;}}
 
+.home-stat-card{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+}
+
+.home-stat-card .stat-value{
+  font-size:1.75rem;
+  font-weight:700;
+  margin-bottom:4px;
+}
+
 .chart-grid{
   display:grid;
   gap:var(--gap);

--- a/public/views/home.html
+++ b/public/views/home.html
@@ -5,6 +5,7 @@
       <h3 class="font-semibold mb-2">Bem-vindo</h3>
       <p>Use os atalhos abaixo para acessar rapidamente as principais áreas.</p>
     </div>
+    <section id="homeStats" class="stats-grid"></section>
     <div class="grid grid-cols-2 gap-4">
       <a href="#contatos" class="btn-primary text-center">Contatos</a>
       <a href="#mapa" class="btn-primary text-center">Mapa</a>


### PR DESCRIPTION
## Summary
- Display Clients, Leads, Visits and Vendas stats on home view
- Populate stats via new renderHomeStats function in agronomo dashboard
- Style stat cards for responsive grid layout

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d41f3008832eaa000771bd1d54f9