### PR TITLE
Render today's agenda on home dashboard

### DIFF
--- a/public/views/home.html
+++ b/public/views/home.html
@@ -6,6 +6,7 @@
       <p>Use os atalhos abaixo para acessar rapidamente as principais áreas.</p>
     </div>
     <section id="homeStats" class="stats-grid"></section>
+    <section id="homeAgenda"><ul id="agendaHoje"></ul></section>
     <div class="grid grid-cols-2 gap-4">
       <a href="#contatos" class="btn-primary text-center">Contatos</a>
       <a href="#mapa" class="btn-primary text-center">Mapa</a>


### PR DESCRIPTION
## Summary
- Add agenda section to home view for quick access to today's tasks
- Implement renderHomeAgenda to populate daily items from agenda store
- Invoke renderHomeAgenda when loading the home view

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d8f13c98832eafb6ecc23633af90