### PR TITLE
feat: add icons and lead badges on dashboard

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -669,6 +669,15 @@ export async function initAgronomoDashboard(userId, userRole) {
     if (el) el.textContent = String(totalActive);
   }
 
+  function interestBadgeClass(interest) {
+    const slug = (interest || '')
+      .toLowerCase()
+      .replace(/\s+/g, '-');
+    if (slug === 'interessado') return 'lead-card--interessado';
+    if (slug === 'sem-interesse') return 'lead-card--sem-interesse';
+    return 'lead-card--default';
+  }
+
   async function renderContactsList(highlightId) {
     const listEl = document.getElementById('contactsList');
     const emptyEl = document.getElementById('contactsEmpty');
@@ -707,6 +716,7 @@ export async function initAgronomoDashboard(userId, userRole) {
           name: l.name,
           farmName: l.farmName,
           type: 'lead',
+          interest: l.interest,
           lastTime: last ? new Date(last.at).getTime() : 0,
         };
       })
@@ -728,14 +738,26 @@ export async function initAgronomoDashboard(userId, userRole) {
     listEl.innerHTML = '';
     items.forEach((it) => {
       const div = document.createElement('div');
-      div.className = 'p-4 bg-white rounded-2xl shadow-md';
+      div.className = 'contact-card';
       if (it.type === 'lead') {
         div.classList.add('lead-card');
         div.dataset.id = it.id;
       }
-      div.innerHTML = `<div class="font-semibold">${
-        it.name || '(sem nome)'
-      }</div><div class="text-sm text-gray-600">${it.farmName || ''}</div>`;
+      const icon = it.type === 'lead' ? 'fa-seedling' : 'fa-user';
+      const badge =
+        it.type === 'lead' && it.interest
+          ? `<span class="lead-badge ${interestBadgeClass(it.interest)}">${it.interest}</span>`
+          : '';
+      div.innerHTML = `
+        <div class="flex items-center gap-2">
+          <i class="fas ${icon}"></i>
+          <div class="flex-1">
+            <div class="font-semibold">${it.name || '(sem nome)'}</div>
+            <div class="text-sm text-gray-600">${it.farmName || ''}</div>
+          </div>
+          ${badge}
+        </div>
+      `;
       const actions = document.createElement('div');
       actions.className = 'mt-2 flex gap-2';
       const visitBtn = document.createElement('button');
@@ -867,15 +889,21 @@ export async function initAgronomoDashboard(userId, userRole) {
     listEl.innerHTML = '';
     items.forEach((it) => {
       const div = document.createElement('div');
-      div.className = 'py-2 cursor-pointer lead-card';
+      div.className = 'contact-card cursor-pointer lead-card';
       div.dataset.id = it.lead.id;
-      div.innerHTML = `<div class="font-semibold">${
-        it.lead.name || '(sem nome)'
-      }</div><div class="text-sm text-gray-600">${
-        it.lead.farmName || ''
-      }</div><div class="text-xs text-gray-500">${
-        it.lead.interest || ''
-      }</div>`;
+      const badge = it.lead.interest
+        ? `<span class="lead-badge ${interestBadgeClass(it.lead.interest)}">${it.lead.interest}</span>`
+        : '';
+      div.innerHTML = `
+        <div class="flex items-center gap-2">
+          <i class="fas fa-seedling"></i>
+          <div class="flex-1">
+            <div class="font-semibold">${it.lead.name || '(sem nome)'}</div>
+            <div class="text-sm text-gray-600">${it.lead.farmName || ''}</div>
+          </div>
+          ${badge}
+        </div>
+      `;
       const canVisit =
         userRole === 'admin' ||
         userRole === 'agronomo' ||

--- a/public/style.css
+++ b/public/style.css
@@ -1218,3 +1218,34 @@ body.has-modal{overflow:hidden;}
   font-size: 2rem;
   font-weight: 700;
 }
+
+/* Contact and lead cards */
+.contact-card {
+  background: var(--card-background);
+  padding: var(--pad);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--gap);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.lead-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-base);
+}
+
+.lead-card--interessado {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+.lead-card--sem-interesse {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+
+.lead-card--default {
+  background: var(--warn-bg);
+  color: var(--warn);
+}


### PR DESCRIPTION
## Summary
- show user and seedling icons in contact and lead cards
- color-code lead interest with badges

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68bad06fa340832e9e00ec11596615ec