### PR TITLE
Add agenda and recent activity cards on homepage

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1214,6 +1214,10 @@ body.has-modal{overflow:hidden;}
 .kpi-icon { @apply w-9 h-9 rounded-full flex items-center justify-center bg-emerald-50 text-emerald-700; }
 .kpi-value:empty { @apply skeleton h-8 w-16; }
 .card-soft { @apply bg-white border border-gray-100 rounded-2xl p-4 md:p-5 shadow-sm; }
+.card-soft h3 {
+  font-weight: 600;
+  margin-bottom: var(--space-1);
+}
 .skeleton { @apply animate-pulse bg-gray-200 rounded; }
 
 /* Reserve space so content never hides under the fixed bottom bar */

--- a/public/views/home.html
+++ b/public/views/home.html
@@ -6,8 +6,18 @@
       <p>Use os atalhos abaixo para acessar rapidamente as principais áreas.</p>
     </div>
     <section id="homeStats" class="stats-grid home-stats"></section>
-    <section id="homeAgenda"><ul id="agendaHoje"></ul></section>
-    <section id="homeRecent"><div id="recentHistory"></div></section>
+    <section id="homeAgenda">
+      <div class="card-soft">
+        <h3 class="font-semibold mb-2">Agenda de hoje</h3>
+        <ul id="agendaHoje"></ul>
+      </div>
+    </section>
+    <section id="homeRecent">
+      <div class="card-soft">
+        <h3 class="font-semibold mb-2">Atividades recentes</h3>
+        <div id="recentHistory"></div>
+      </div>
+    </section>
     <div class="grid grid-cols-2 gap-4">
       <a href="#contatos" class="btn-primary text-center">Contatos</a>
       <a href="#mapa" class="btn-primary text-center">Mapa</a>


### PR DESCRIPTION
## Summary
- wrap today's agenda and recent history sections in `card-soft` cards and add titles
- style card titles for consistent spacing and weight

## Testing
- `npm test` *(fails: vitest not found)*
- `npx -y vitest run` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0cfc42a4832ea1df64938966c1ee