### PR TITLE
Add network status indicator to agronomo dashboard

### DIFF
--- a/public/dashboard-agronomo.html
+++ b/public/dashboard-agronomo.html
@@ -30,6 +30,7 @@
         <button onclick="logout()" class="px-3 py-1.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 text-sm">Sair</button>
       </div>
     </div>
+    <div id="networkStatus" class="text-sm font-medium"></div>
   </header>
 
   <main id="agroMain" class="pb-16"></main>

--- a/public/style.css
+++ b/public/style.css
@@ -1237,13 +1237,13 @@ body.has-modal{overflow:hidden;}
 }
 
 #networkStatus.online {
-    background-color: #d1fae5;
-    color: #065f46;
+    background-color: #16a34a;
+    color: #ffffff;
 }
 
 #networkStatus.offline {
-    background-color: #fee2e2;
-    color: #991b1b;
+    background-color: #dc2626;
+    color: #ffffff;
 }
 
 /* Weather widget styles */


### PR DESCRIPTION
## Summary
- show network status indicator in agronomo dashboard header
- improve network status colors for better contrast

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1bb2fee8832eb6f826d1025ce3fa