### PR TITLE
feat: add weather icons

### DIFF
--- a/public/js/weather.js
+++ b/public/js/weather.js
@@ -19,8 +19,40 @@ export async function renderWeather() {
     const data = await res.json();
     if (!data.current_weather) throw new Error('Sem dados');
     const w = data.current_weather;
+    const iconMap = {
+      0: { icon: 'fa-sun', type: 'sun' },
+      1: { icon: 'fa-cloud-sun', type: 'cloud' },
+      2: { icon: 'fa-cloud-sun', type: 'cloud' },
+      3: { icon: 'fa-cloud', type: 'cloud' },
+      45: { icon: 'fa-smog', type: 'fog' },
+      48: { icon: 'fa-smog', type: 'fog' },
+      51: { icon: 'fa-cloud-rain', type: 'rain' },
+      53: { icon: 'fa-cloud-rain', type: 'rain' },
+      55: { icon: 'fa-cloud-rain', type: 'rain' },
+      56: { icon: 'fa-cloud-rain', type: 'rain' },
+      57: { icon: 'fa-cloud-rain', type: 'rain' },
+      61: { icon: 'fa-cloud-rain', type: 'rain' },
+      63: { icon: 'fa-cloud-rain', type: 'rain' },
+      65: { icon: 'fa-cloud-showers-heavy', type: 'rain' },
+      66: { icon: 'fa-cloud-showers-heavy', type: 'rain' },
+      67: { icon: 'fa-cloud-showers-heavy', type: 'rain' },
+      71: { icon: 'fa-snowflake', type: 'snow' },
+      73: { icon: 'fa-snowflake', type: 'snow' },
+      75: { icon: 'fa-snowflake', type: 'snow' },
+      77: { icon: 'fa-snowflake', type: 'snow' },
+      80: { icon: 'fa-cloud-showers-heavy', type: 'rain' },
+      81: { icon: 'fa-cloud-showers-heavy', type: 'rain' },
+      82: { icon: 'fa-cloud-showers-heavy', type: 'rain' },
+      85: { icon: 'fa-snowflake', type: 'snow' },
+      86: { icon: 'fa-snowflake', type: 'snow' },
+      95: { icon: 'fa-bolt', type: 'storm' },
+      96: { icon: 'fa-bolt', type: 'storm' },
+      99: { icon: 'fa-bolt', type: 'storm' }
+    };
+    const iconData = iconMap[w.weathercode] || { icon: 'fa-question', type: 'unknown' };
     container.innerHTML = `
       <div class="text-center">
+        <i class="fas ${iconData.icon} weather-icon ${iconData.type}"></i>
         <div class="text-lg font-semibold">${Math.round(w.temperature)}°C</div>
         <div class="text-xs text-gray-600">Vento ${Math.round(w.windspeed)} km/h</div>
       </div>

--- a/public/style.css
+++ b/public/style.css
@@ -198,6 +198,22 @@ letter-spacing: normal;
     position: relative;
 }
 
+/* Weather icons */
+.weather-icon {
+    display: inline-block;
+    font-size: 1.5rem;
+    margin-bottom: 0.25rem;
+    vertical-align: middle;
+}
+
+.weather-icon.sun { color: #fbbf24; }
+.weather-icon.cloud { color: #9ca3af; }
+.weather-icon.rain { color: #3b82f6; }
+.weather-icon.snow { color: #60a5fa; }
+.weather-icon.storm { color: #f97316; }
+.weather-icon.fog { color: #6b7280; }
+.weather-icon.unknown { color: var(--muted); }
+
 .login-background::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## Summary
- map Open-Meteo weather codes to Font Awesome icons
- style weather icon element with alignment and condition colors

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb21953cc4832ea892cb4f8ed83a5e