### PR TITLE
Fix lead details header, modal position and conversion

### DIFF
--- a/public/js/pages/agro-bottom-nav.js
+++ b/public/js/pages/agro-bottom-nav.js
@@ -67,16 +67,18 @@ export function toggleModal(el, open) {
     lastFocusedElement = document.activeElement;
     currentModal = el;
     el.classList.remove('hidden');
+    el.classList.add('show');
     focusableElements = el.querySelectorAll(
       'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])'
     );
-    focusableElements[0]?.focus();
+    focusableElements[0]?.focus({ preventScroll: true });
     document.addEventListener('keydown', handleKeydown);
   } else {
     el.classList.add('hidden');
+    el.classList.remove('show');
     document.removeEventListener('keydown', handleKeydown);
     currentModal = null;
     focusableElements = [];
-    lastFocusedElement?.focus();
+    lastFocusedElement?.focus({ preventScroll: true });
   }
 }

--- a/public/js/pages/lead-details.js
+++ b/public/js/pages/lead-details.js
@@ -10,6 +10,7 @@ import {
   doc,
   getDoc,
   updateDoc,
+  deleteDoc,
   collection,
   addDoc,
   onSnapshot,
@@ -32,6 +33,7 @@ export function initLeadDetails(userId, userRole) {
   });
 
   const leadNameHeader = document.getElementById('leadNameHeader');
+  const breadcrumbLeadName = document.getElementById('breadcrumbLeadName');
   const leadName = document.getElementById('leadName');
   const leadPhone = document.getElementById('leadPhone');
   const leadEmail = document.getElementById('leadEmail');
@@ -86,6 +88,7 @@ export function initLeadDetails(userId, userRole) {
     const name =
       lead.name || lead.nomeContato || lead.displayName || '(Sem nome)';
     if (leadNameHeader) leadNameHeader.textContent = name;
+    if (breadcrumbLeadName) breadcrumbLeadName.textContent = name;
     if (leadName) leadName.textContent = name;
     if (leadPhone)
       leadPhone.textContent = lead.phone || lead.phoneNumber || '';
@@ -149,6 +152,7 @@ export function initLeadDetails(userId, userRole) {
     const name =
       data.name || data.nomeContato || data.displayName || '(Sem nome)';
     if (leadNameHeader) leadNameHeader.textContent = name;
+    if (breadcrumbLeadName) breadcrumbLeadName.textContent = name;
     if (leadName) leadName.textContent = name;
     if (leadPhone)
       leadPhone.textContent = data.phone || data.phoneNumber || '';
@@ -496,6 +500,7 @@ export function initLeadDetails(userId, userRole) {
         propertyCount: 0,
         cultureCount: 0,
         enabledModules: {},
+        leadId,
       });
       // Ensure a property with coordinates exists so maps can display the client
       try {
@@ -520,7 +525,7 @@ export function initLeadDetails(userId, userRole) {
       } catch (geoErr) {
         console.warn('[lead->client] Failed to create property with coordinates', geoErr);
       }
-      await updateDoc(leadRef, { stage: 'Convertido', clientId: clientRef.id });
+      await deleteDoc(leadRef);
       showToast('Lead convertido em cliente!', 'success');
       setTimeout(() => {
         window.location.href = `client-details.html?clientId=${clientRef.id}`;

--- a/public/lead-details.html
+++ b/public/lead-details.html
@@ -19,20 +19,17 @@
       <nav class="text-xs text-gray-500 mb-2">
         <a href="dashboard-agronomo.html" class="hover:text-gray-700">Leads</a>
         <span class="mx-1">/</span>
-        <span>Detalhes do Lead</span>
+        <span id="breadcrumbLeadName">Detalhes do Lead</span>
       </nav>
       <div class="flex justify-between items-start">
         <div class="flex items-start gap-4">
           <a id="backBtn" class="text-gray-500 hover:text-gray-800 mt-1" title="Voltar"><i class="fas fa-arrow-left"></i></a>
-          <div>
-            <h1 class="text-2xl font-bold" style="color: var(--brand-green);">Detalhes do Lead</h1>
-            <div class="flex items-center gap-2 mt-1">
-              <span id="leadNameHeader" class="text-lg font-semibold text-gray-800">Carregando...</span>
-              <a id="editLead" class="action-icon" title="Editar"><i class="fas fa-edit"></i></a>
-              <a id="callLead" class="action-icon" title="Ligar"><i class="fas fa-phone"></i></a>
-              <a id="messageLead" class="action-icon" title="Mensagem"><i class="fas fa-comment-dots"></i></a>
-              <button id="convertLead" class="btn-primary text-xs px-2 py-1">Converter em Cliente</button>
-            </div>
+          <div class="flex items-center gap-2">
+            <h1 id="leadNameHeader" class="text-2xl font-bold" style="color: var(--brand-green);">Carregando...</h1>
+            <a id="editLead" class="action-icon" title="Editar"><i class="fas fa-edit"></i></a>
+            <a id="callLead" class="action-icon" title="Ligar"><i class="fas fa-phone"></i></a>
+            <a id="messageLead" class="action-icon" title="Mensagem"><i class="fas fa-comment-dots"></i></a>
+            <button id="convertLead" class="btn-primary text-xs px-2 py-1">Converter em Cliente</button>
           </div>
         </div>
         <button onclick="logout()" class="px-4 py-2 bg-red-600 text-white font-bold rounded-lg hover:bg-red-700 text-sm">Sair</button>
@@ -87,7 +84,7 @@
     </section>
   </main>
   <!-- Modal de registro de visita -->
-  <div id="leadAddVisitModal" class="modal hidden">
+  <div id="leadAddVisitModal" class="modal-overlay hidden">
     <div class="modal-card w-full max-w-md relative">
       <button type="button" id="btnLeadVisitCloseIcon" aria-label="Fechar" class="btn-icon absolute top-2 right-2 text-gray-500 hover:text-gray-700">
         <i class="fas fa-times"></i>
@@ -137,7 +134,7 @@
   </div>
 
   <!-- Modal de edição do lead -->
-  <div id="editLeadModal" class="modal hidden">
+  <div id="editLeadModal" class="modal-overlay hidden">
     <div class="modal-card w-full max-w-md relative">
       <button type="button" id="btnEditLeadCloseIcon" aria-label="Fechar" class="btn-icon absolute top-2 right-2 text-gray-500 hover:text-gray-700">
         <i class="fas fa-times"></i>


### PR DESCRIPTION
## Summary
- Show lead name in lead-details header and breadcrumb
- Prevent modal from opening at page bottom and keep focus without scrolling
- Convert lead to client by creating client and deleting original lead

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @capacitor/android)*

------
https://chatgpt.com/codex/tasks/task_e_68c4061ab998832e9c0a25cb7907032b