### PR TITLE
fix: avoid freeze when geolocation stalled

### DIFF
--- a/public/js/utils/geo.js
+++ b/public/js/utils/geo.js
@@ -1,9 +1,28 @@
-export async function getCurrentPositionSafe() {
+export async function getCurrentPositionSafe(timeout = 10000) {
   if (!('geolocation' in navigator)) return null;
   return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        resolve(null);
+      }
+    }, timeout);
     navigator.geolocation.getCurrentPosition(
-      (pos) => resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
-      () => resolve(null)
+      (pos) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        }
+      },
+      () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(null);
+        }
+      }
     );
   });
 }


### PR DESCRIPTION
## Summary
- ensure geolocation resolves after timeout to avoid freezes when offline

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c41ee0fbe8832e869d87c7315dcab5