### PR TITLE
Corrige congelamento da barra inferior ao registrar visitas offline

### DIFF
--- a/agronomooffline/index.html
+++ b/agronomooffline/index.html
@@ -142,19 +142,22 @@
     </button>
   </nav>
 
-  <div id="quickActionsModal" class="modal hidden">
-    <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="quickActionsTitle" tabindex="-1">
-      <h3 id="quickActionsTitle" class="mb-4 font-semibold">Ações Rápidas</h3>
-      <div class="flex flex-col gap-2 mb-4">
-        <button id="btnQuickAddContato" class="btn-primary" autofocus>Adicionar contato</button>
-        <button id="btnQuickRegVisita" class="btn-primary">Registrar Visita</button>
+  <div id="quickActionsModal" class="modal-overlay hidden">
+    <div class="modal">
+      <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="quickActionsTitle" tabindex="-1">
+        <h3 id="quickActionsTitle" class="mb-4 font-semibold">Ações Rápidas</h3>
+        <div class="flex flex-col gap-2 mb-4">
+          <button id="btnQuickAddContato" class="btn-primary" autofocus>Adicionar contato</button>
+          <button id="btnQuickRegVisita" class="btn-primary">Registrar Visita</button>
+        </div>
+        <button id="btnQuickClose" class="btn-secondary w-full">Fechar</button>
       </div>
-      <button id="btnQuickClose" class="btn-secondary w-full">Fechar</button>
     </div>
   </div>
 
-  <div id="visitModal" class="modal hidden">
-    <div class="modal-card max-w-xl w-full" role="dialog" aria-modal="true" aria-labelledby="visitModalTitle" tabindex="-1">
+  <div id="visitModal" class="modal-overlay hidden">
+    <div class="modal">
+      <div class="modal-card max-w-xl w-full" role="dialog" aria-modal="true" aria-labelledby="visitModalTitle" tabindex="-1">
       <h3 id="visitModalTitle" class="mb-4 font-semibold">Registrar Visita</h3>
       <form id="visitForm" class="grid gap-4">
         <div>
@@ -221,11 +224,13 @@
           <button type="submit" class="btn-primary">Salvar</button>
         </div>
       </form>
+      </div>
     </div>
   </div>
 
-  <div id="saleModal" class="modal hidden">
-    <div class="modal-card max-w-md w-full" role="dialog" aria-modal="true" aria-labelledby="saleModalTitle" tabindex="-1">
+  <div id="saleModal" class="modal-overlay hidden">
+    <div class="modal">
+      <div class="modal-card max-w-md w-full" role="dialog" aria-modal="true" aria-labelledby="saleModalTitle" tabindex="-1">
       <h3 id="saleModalTitle" class="mb-4 font-semibold">Registrar Venda</h3>
       <form id="saleForm" class="grid gap-4">
         <div class="field">
@@ -245,11 +250,13 @@
           <button type="submit" class="btn-primary">Salvar</button>
         </div>
       </form>
+      </div>
     </div>
   </div>
 
-  <div id="leadVisitModal" class="modal hidden">
-    <div class="modal-card max-w-md w-full" role="dialog" aria-modal="true" aria-labelledby="leadVisitModalTitle" tabindex="-1">
+  <div id="leadVisitModal" class="modal-overlay hidden">
+    <div class="modal">
+      <div class="modal-card max-w-md w-full" role="dialog" aria-modal="true" aria-labelledby="leadVisitModalTitle" tabindex="-1">
       <h3 id="leadVisitModalTitle" class="mb-4 font-semibold">Registrar Visita</h3>
       <form id="leadVisitForm" class="grid gap-4">
         <div class="field">
@@ -298,11 +305,13 @@
           <button type="submit" class="btn-primary">Salvar</button>
         </div>
       </form>
+      </div>
     </div>
   </div>
 
-  <div id="quickCreateModal" class="modal hidden">
-    <div class="modal-card max-w-xl w-full" role="dialog" aria-modal="true" aria-labelledby="quickCreateModalTitle" tabindex="-1">
+  <div id="quickCreateModal" class="modal-overlay hidden">
+    <div class="modal">
+      <div class="modal-card max-w-xl w-full" role="dialog" aria-modal="true" aria-labelledby="quickCreateModalTitle" tabindex="-1">
       <h3 id="quickCreateModalTitle" class="mb-4 font-semibold">Cadastro Rápido</h3>
       <form id="quickCreateForm" class="grid gap-4">
         <div>
@@ -334,6 +343,7 @@
           <button type="submit" class="btn-primary">Salvar</button>
         </div>
       </form>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Sumário
- ajusta estrutura de modais no painel offline para evitar bloqueio da barra inferior

## Testes
- `npm test` *(falhou: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c420f3739c832e97fbd9a432f39245