### PR TITLE
Fix bottom bar blocked after visit registration

### DIFF
--- a/public/js/pages/dashboard-agronomo.js
+++ b/public/js/pages/dashboard-agronomo.js
@@ -98,16 +98,15 @@ function toggleModal(el, open) {
     overlay.addEventListener('click', overlay.__closeHandler);
   } else {
     overlay.classList.remove('show');
+    const hide = () => overlay.classList.add('hidden');
     overlay.addEventListener(
       'transitionend',
-      function handler(e) {
-        if (e.target === overlay) {
-          overlay.classList.add('hidden');
-          overlay.removeEventListener('transitionend', handler);
-        }
+      (e) => {
+        if (e.target === overlay) hide();
       },
       { once: true }
     );
+    setTimeout(hide, 300);
     document.removeEventListener('keydown', handleModalKeydown);
     overlay.removeEventListener('click', overlay.__closeHandler);
     currentModal = null;


### PR DESCRIPTION
## Summary
- ensure visit modal overlay hides even if transitionend doesn't fire

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4578f12bc832e9007ed49e12d7e95